### PR TITLE
Literal syntax

### DIFF
--- a/src/common/core-functions.k
+++ b/src/common/core-functions.k
@@ -168,7 +168,6 @@ rule getSimpleName(class ClassId:Id)
 /*@ \subsection{Identifiers}*/
 
 //@ 'Id(Str:String)
-syntax KLabel ::= "'Id"
 
 /*@Convert the AST representation of an Id into a K Id.*/
 rule 'Id(Str:String) => String2Id(Str)                [structural, anywhere]

--- a/src/common/core-sorts.k
+++ b/src/common/core-sorts.k
@@ -1,33 +1,7 @@
 require "lexical-syntax.k"
 require "literal-syntax.k"
+require "type-syntax.k"
 //@ \section{Module CORE-SORTS}
-module TYPE-SYNTAX
-     //@ \subsection{Types}
-        syntax Type ::= PrimitiveType
-                      | RefType
-                      | "void" [klabel('Void)]
-
-        syntax IntOrLongType ::= "int" [klabel('Int)] | "long" [klabel('Long)]
-        syntax IntType ::= "byte" [klabel('Byte)]| "short" [klabel('Short)]| IntOrLongType | "char" [klabel('Char)]
-        syntax FloatType ::= "float" [klabel('Float)] | "double" [klabel('Double)]
-        syntax NumericType ::= IntType | FloatType
-        syntax PrimitiveType ::= NumericType | "bool" [klabel('Boolean)]
-
-
-    /*@ A fully qualified class name, or noClass where no valid class could be computed.*/
-    syntax ClassType ::= "class" Id
-                       | "noClass"        [latex({\dotCt{K}})]
-
-    /* A reference type is either a class type, an array type, the null type or a String type. The null type is specified
-        by the JLS although inaccessible to the programmer. String objects and types are not threated as regular objects
-        in the present semantics for performance reasons.
-    */
-    syntax RefType ::= ClassType
-                     | "arrayOf" Type
-                     | "nullType"
-
-endmodule
-
 module CORE-SORTS
     imports TYPE-SYNTAX
     imports LEXICAL-SYNTAX

--- a/src/common/core-sorts.k
+++ b/src/common/core-sorts.k
@@ -1,4 +1,5 @@
 require "lexical-syntax.k"
+require "literal-syntax.k"
 //@ \section{Module CORE-SORTS}
 module TYPE-SYNTAX
      //@ \subsection{Types}
@@ -30,6 +31,7 @@ endmodule
 module CORE-SORTS
     imports TYPE-SYNTAX
     imports LEXICAL-SYNTAX
+    imports LITERAL-SYNTAX
 
 //@ \subsection{Computation phases}
 
@@ -173,7 +175,7 @@ syntax ArrayRef ::=   arrayRef (
                         Int    // Length
                       )
 
-syntax RawRefVal ::= ObjectRef | ArrayRef | String | "null"
+syntax RawRefVal ::= ObjectRef | ArrayRef | String | NullLiteral
 
 /*@ A typed value is a pair of of a raw value and a type. Anywhere during execution we will evaluated typed expressions
     into typed values, never into raw values alone.

--- a/src/common/core-sorts.k
+++ b/src/common/core-sorts.k
@@ -28,6 +28,7 @@ endmodule
 
 module CORE-SORTS
     imports TYPE-SYNTAX
+    imports LEXICAL-SYNTAX
 
 //@ \subsection{Computation phases}
 
@@ -184,20 +185,8 @@ syntax TypedVal ::= RawVal "::" Type
 syntax KResult ::= TypedVal | Type
 
 /*@ Member access modes*/
-syntax AccessMode ::= //"public" | "protected"  | "private"
-Modifier | "package"
+syntax AccessMode ::= Public | Protected  | Private | "package"
 syntax KResult ::= AccessMode
-
-syntax Modifier ::= "public"  [klabel('Public)]
-                  | "private"  [klabel('Private)]
-                  | "protected" [klabel('Protected)]
-                  | "abstract"  [klabel('Abstract)]
-                  | "final" [klabel('Final)]
-                  | "static" [klabel('Static)]
-                  | "native" [klabel('Native)]
-                  | "transient" [klabel('Transient)]
-                  | "volatile" [klabel('Volatile)]
-                  | "strictfp" [klabel('StrictFP)]
 
 /*@ Types of routines represented by a method closure*/
 syntax MethodMetaType ::= "methodMMT" | "constructorMMT"

--- a/src/common/core-sorts.k
+++ b/src/common/core-sorts.k
@@ -1,3 +1,4 @@
+require "lexical-syntax.k"
 //@ \section{Module CORE-SORTS}
 module TYPE-SYNTAX
      //@ \subsection{Types}

--- a/src/common/java-syntax.k
+++ b/src/common/java-syntax.k
@@ -1,0 +1,12 @@
+require "exp-syntax.k"
+require "stmt-syntax.k"
+require "list-syntax.k"
+require "lexical-syntax.k"
+require "literal-syntax.k"
+module JAVA-SYNTAX
+    imports LIST-SYNTAX
+    imports STMT-SYNTAX
+    imports EXP-SYNTAX
+    imports LEXICAL-SYNTAX
+    imports LITERAL-SYNTAX
+endmodule

--- a/src/common/lexical-syntax.k
+++ b/src/common/lexical-syntax.k
@@ -19,6 +19,6 @@ syntax Modifier ::= Public
                   | Native
                   | Transient
                   | Volatile
-                  | Strictfp
+                  | StrictFP
 
 endmodule

--- a/src/common/lexical-syntax.k
+++ b/src/common/lexical-syntax.k
@@ -2,9 +2,9 @@ module LEXICAL-SYNTAX
 //@ \subsection{Comments.sdf}
 //no need to define because K provides fixed layout
 
-//@ \subsection{Id.sdf} todo
-//syntax Id ::= ID [klabel('Id)]
-//syntax ID ::= Token{[A-Za-z\_\$][A-Za-z0-9\_\$]*}
+//@ \subsection{Identifiers.sdf}
+syntax Id ::= ID [klabel('Id)]
+syntax ID ::= Token{[A-Za-z\_\$][A-Za-z0-9\_\$]*} [onlyLabel]
 
 //@ \subsection{KeyWord.sdf(not needed?)}
 /*

--- a/src/common/lexical-syntax.k
+++ b/src/common/lexical-syntax.k
@@ -1,6 +1,7 @@
 module LEXICAL-SYNTAX
 //@ \subsection{Comments.sdf}
-//@ \subsection{Id.sdf}
+
+//@ \subsection{Id.sdf} todo
 //syntax Id ::= ID [klabel('Id)]
 //syntax ID ::= Token{[A-Za-z\_\$][A-Za-z0-9\_\$]*}
 syntax ID ::= //KeyWord [reject] only terminals can be rejected todo
@@ -83,10 +84,6 @@ syntax Modifier ::= Public
                   | Transient
                   | Volatile
                   | StrictFP
-
-//@ \subsection{BooleanLiterals.sdf}
-syntax BoolLiteral ::= Bool [klabel('Bool)]
-//syntax Bool ::= true [klabel('True)] todo:"true"?
 
 //@ \subsection{UnicodeEscape.sdf}
 syntax UnicodeEscape ::= Token {"\\" [u]+ [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]} [klabel('UnicodeEscape)]

--- a/src/common/lexical-syntax.k
+++ b/src/common/lexical-syntax.k
@@ -5,10 +5,6 @@ module LEXICAL-SYNTAX
 //@ \subsection{Id.sdf} todo
 //syntax Id ::= ID [klabel('Id)]
 //syntax ID ::= Token{[A-Za-z\_\$][A-Za-z0-9\_\$]*}
-syntax ID ::= //KeyWord [reject] only terminals can be rejected todo
-              "true"  [reject]
-            | "false" [reject]
-            | "null"  [reject]
 
 //@ \subsection{KeyWord.sdf(not needed?)}
 /*
@@ -65,6 +61,12 @@ syntax Keyword ::= "abstract"
 */
 
 //@ \subsection{LineTerminators.sdf}
+syntax EndOfFile
+syntax CarriageReturn ::= Token{[\r]}
+syntax LineTerminator ::= EndOfFile
+                        | CarriageReturn
+                        | Token{[\n]}
+                        | Token{[\r][\n]}
 
 //@ \subsection{Modifiers.sdf}
 syntax Public ::= "public"  [klabel('Public)]

--- a/src/common/lexical-syntax.k
+++ b/src/common/lexical-syntax.k
@@ -1,5 +1,6 @@
 module LEXICAL-SYNTAX
 //@ \subsection{Comments.sdf}
+//no need to define because K provides fixed layout
 
 //@ \subsection{Id.sdf} todo
 //syntax Id ::= ID [klabel('Id)]
@@ -63,6 +64,8 @@ syntax Keyword ::= "abstract"
                  | "while"
 */
 
+//@ \subsection{LineTerminators.sdf}
+
 //@ \subsection{Modifiers.sdf}
 syntax Public ::= "public"  [klabel('Public)]
 syntax Private ::= "private"  [klabel('Private)]
@@ -87,4 +90,7 @@ syntax Modifier ::= Public
 
 //@ \subsection{UnicodeEscape.sdf}
 syntax UnicodeEscape ::= Token {"\\" [u]+ [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]} [klabel('UnicodeEscape)]
+
+//@ \subsection{WhiteSpace.sdf}
+//no need to define because K provides fixed layout
 endmodule

--- a/src/common/lexical-syntax.k
+++ b/src/common/lexical-syntax.k
@@ -1,0 +1,24 @@
+module LEXICAL-SYNTAX
+//@ \subsection{Modifiers.sdf}
+syntax Public ::= "public"  [klabel('Public)]
+syntax Private ::= "private"  [klabel('Private)]
+syntax Protected ::= "protected" [klabel('Protected)]
+syntax Abstract ::= "abstract"  [klabel('Abstract)]
+syntax Final ::= "final" [klabel('Final)]
+syntax Static ::= "static" [klabel('Static)]
+syntax Native ::= "native" [klabel('Native)]
+syntax Transient ::= "transient" [klabel('Transient)]
+syntax Volatile ::= "volatile" [klabel('Volatile)]
+syntax StrictFP ::= "strictfp" [klabel('StrictFP)]
+syntax Modifier ::= Public
+                  | Private
+                  | Protected
+                  | Abstract
+                  | Final
+                  | Static
+                  | Native
+                  | Transient
+                  | Volatile
+                  | Strictfp
+
+endmodule

--- a/src/common/lexical-syntax.k
+++ b/src/common/lexical-syntax.k
@@ -1,4 +1,67 @@
 module LEXICAL-SYNTAX
+//@ \subsection{Comments.sdf}
+//@ \subsection{Id.sdf}
+//syntax Id ::= ID [klabel('Id)]
+//syntax ID ::= Token{[A-Za-z\_\$][A-Za-z0-9\_\$]*}
+syntax ID ::= //KeyWord [reject] only terminals can be rejected todo
+              "true"  [reject]
+            | "false" [reject]
+            | "null"  [reject]
+
+//@ \subsection{KeyWord.sdf(not needed?)}
+/*
+syntax Keyword ::= "abstract"
+                 | "assert"
+                 | "boolean"
+                 | "break"
+                 | "byte"          
+                 | "case"          
+                 | "catch"         
+                 | "char"          
+                 | "class"         
+                 | "const"         
+                 | "continue"      
+                 | "default"       
+                 | "do"            
+                 | "double"        
+                 | "else"          
+                 | "enum"          
+                 | "extends"       
+                 | "final"         
+                 | "finally"       
+                 | "float"         
+                 | "for"           
+                 | "goto"          
+                 | "if"            
+                 | "implements"    
+                 | "import"        
+                 | "instanceof"    
+                 | "int"           
+                 | "interface"     
+                 | "long"          
+                 | "native"        
+                 | "new"           
+                 | "package"       
+                 | "private"       
+                 | "protected"     
+                 | "public"        
+                 | "return"        
+                 | "short"         
+                 | "static"        
+                 | "strictfp"      
+                 | "super"         
+                 | "switch"        
+                 | "synchronized"  
+                 | "this"          
+                 | "throw"         
+                 | "throws"        
+                 | "transient"     
+                 | "try"           
+                 | "void"          
+                 | "volatile"      
+                 | "while"
+*/
+
 //@ \subsection{Modifiers.sdf}
 syntax Public ::= "public"  [klabel('Public)]
 syntax Private ::= "private"  [klabel('Private)]
@@ -21,4 +84,10 @@ syntax Modifier ::= Public
                   | Volatile
                   | StrictFP
 
+//@ \subsection{BooleanLiterals.sdf}
+syntax BoolLiteral ::= Bool [klabel('Bool)]
+//syntax Bool ::= true [klabel('True)] todo:"true"?
+
+//@ \subsection{UnicodeEscape.sdf}
+syntax UnicodeEscape ::= Token {"\\" [u]+ [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]} [klabel('UnicodeEscape)]
 endmodule

--- a/src/common/lexical-syntax.k
+++ b/src/common/lexical-syntax.k
@@ -62,11 +62,11 @@ syntax Keyword ::= "abstract"
 
 //@ \subsection{LineTerminators.sdf}
 syntax EndOfFile
-syntax CarriageReturn ::= Token{[\r]}
+syntax CarriageReturn ::= Token{[\r]}              [onlyLabel]
 syntax LineTerminator ::= EndOfFile
                         | CarriageReturn
-                        | Token{[\n]}
-                        | Token{[\r][\n]}
+                        | Token{[\n]}              [onlyLabel]
+                        | Token{[\r][\n]}          [onlyLabel]
 
 //@ \subsection{Modifiers.sdf}
 syntax Public ::= "public"  [klabel('Public)]
@@ -91,7 +91,7 @@ syntax Modifier ::= Public
                   | StrictFP
 
 //@ \subsection{UnicodeEscape.sdf}
-syntax UnicodeEscape ::= Token {"\\" [u]+ [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]} [klabel('UnicodeEscape)]
+syntax UnicodeEscape ::= Token {[\\][u]+ [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]} [onlyLabel, klabel('UnicodeEscape)]
 
 //@ \subsection{WhiteSpace.sdf}
 //no need to define because K provides fixed layout

--- a/src/common/list-syntax.k
+++ b/src/common/list-syntax.k
@@ -72,7 +72,7 @@ syntax UserList ::=     BlockStmList
 /* todo: Syntax below should be put in other modules when they are perfectly defined. */
                       syntax   InterfaceType
                       syntax   ExceptionType
-                      syntax   Id
+
                       syntax   TypeDec::= ClassDec
                       syntax   VarDec
                       syntax   ImportDec

--- a/src/common/list-syntax.k
+++ b/src/common/list-syntax.k
@@ -1,5 +1,8 @@
+require "stmt-syntax.k"
+require "literal-syntax.k"
 module LIST-SYNTAX
 imports STMT-SYNTAX
+imports LITERAL-SYNTAX
 /*A module for list only, for the easy of implementation and management.
  There are six lists ((formal)params, dims, dimexps, exps, varinits, catchclauses)
  already defined before, because there is no automatic refactor for rename, and also those
@@ -90,7 +93,7 @@ syntax UserList ::=     BlockStmList
                       syntax   InterfaceMemberDec
                       syntax   ElemValPair
                       syntax   ElemVal
-                      syntax   StringPart
+
                       syntax   EnumConst
                       syntax   ClassBodyDec
 

--- a/src/common/literal-syntax.k
+++ b/src/common/literal-syntax.k
@@ -13,16 +13,17 @@ syntax SingleChar// ::= Token{[\r\n\'\\]}//don't understand ^?
 syntax CharContent ::= SingleChar [klabel('Single)]
                      | UnicodeEscape
                      | EscapeSeq
-syntax CharLiteral //::= "\'" CharContent "\'"  [klabel('Char)]
+//Problem: Multiple lookahead not fully supported (does not appear when tested in small language)
+syntax CharLiteral //::= "'" CharContent "'"  [klabel('Char)]
 
 //@ \subsection{EscapeSequences.sdf}
 
 syntax EscapeSeq ::= OctaEscape | NamedEscape
-syntax NamedEscape ::= Token{"\\" [btnfr\"\'\\]}         [klabel('NamedEscape)]
-syntax OctaEscape ::= Token{"\\" [0-7]}                  [klabel('OctaEscape1)]
-                    | Token{"\\" [0-3][0-7]}             [klabel('OctaEscape2)]
-                    | Token{"\\" [4-7][0-7]}             [klabel('OctaEscape2)]
-                    | Token{"\\" [0-3][0-7][0-7]}        [klabel('OctaEscape3)]
+syntax NamedEscape ::= Token{"\\" [btnfr\"\'\\]}         [onlyLabel, klabel('NamedEscape)]
+syntax OctaEscape ::= Token{"\\" [0-7]}                  [onlyLabel, klabel('OctaEscape1)]
+                    | Token{"\\" [0-3][0-7]}             [onlyLabel, klabel('OctaEscape2)]
+                    | Token{"\\" [4-7][0-7]}             [onlyLabel, klabel('OctaEscape2)]
+                    | Token{"\\" [0-3][0-7][0-7]}        [onlyLabel, klabel('OctaEscape3)]
 
 //@ \subsection{FloatingPointLiterals.sdf} todo
 syntax FloatLiteral ::= Float      [klabel('Float)]

--- a/src/common/literal-syntax.k
+++ b/src/common/literal-syntax.k
@@ -3,9 +3,10 @@ require "list-syntax.k"
 module LITERAL-SYNTAX
 imports LEXICAL-SYNTAX
 imports LIST-SYNTAX
-//@ \subsection{BooleanLiterals.sdf} todo
+//@ \subsection{BooleanLiterals.sdf}
 syntax BoolLiteral ::= Bool [klabel('Bool)]
-//syntax Bool ::= true [klabel('True)] todo:"true"?
+syntax Bool ::= "true"  [onlyLabel, klabel('True)]
+syntax Bool ::= "false" [onlyLabel, klabel('False)]
 
 //@ \subsection{CharacterLiterals.sdf} todo
 syntax SingleChar// ::= Token{[\r\n\'\\]}//don't unserstand ^?

--- a/src/common/literal-syntax.k
+++ b/src/common/literal-syntax.k
@@ -1,6 +1,8 @@
 require "lexical-syntax.k"
+require "list-syntax.k"
 module LITERAL-SYNTAX
 imports LEXICAL-SYNTAX
+imports LIST-SYNTAX
 //@ \subsection{BooleanLiterals.sdf} todo
 syntax BoolLiteral ::= Bool [klabel('Bool)]
 //syntax Bool ::= true [klabel('True)] todo:"true"?
@@ -25,25 +27,31 @@ syntax OctaEscape ::= Token{"\\" [0-7]}                  [klabel('OctaEscape1)]
 
 //@ \subsection{IntegerLiterals.sdf}
 //inline token declaration not allowed
-//syntax Ll ::= Token{[lL]?}
-//
+//syntax Ll ::= Token{[lL]} cannot define "L"
+
+//java heap space problem, same code on small language test works
 //syntax DeciNumeral ::=  Token{[1-9][0-9]*} //| "0"
-//syntax DeciLiteral ::= DeciNumeral Ll
+//syntax DeciLiteral ::= DeciNumeral
 //
 //syntax HexaNumeral ::= Token{[0][xX] [0-9a-fA-F]+}
-//syntax HexaLiteral ::= HexaNumeral Ll
+//syntax HexaLiteral ::= HexaNumeral
+//
 //syntax OctaNumeral ::= Token{[0]     [0-7]+}
-//syntax OctaLiteral ::= OctaNumeral Ll
+//syntax OctaLiteral ::= OctaNumeral
 //
 //syntax IntLiteral ::= DeciLiteral [klabel('Deci)]
 //                    | HexaLiteral [klabel('Hexa)]
 //                    | OctaLiteral [klabel('Octa)]
 
-//@ \subsection{FloatingPointLiterals.sdf} todo
 
 //@ \subsection{NullLiteral.sdf}
 syntax NullLiteral ::= "null" [klabel('Null)]
 
 //@ \subsection{StringLiterals.sdf} todo
+syntax StringLiteral ::= "\"" StringPartList "\"" [klabel('String)]
+syntax StringPart ::= StringChars [klabel('Chars)]
+                    | UnicodeEscape
+                    | EscapeSeq
+syntax StringChars //::= Token {~[\"\\\n\13]}
 
 endmodule

--- a/src/common/literal-syntax.k
+++ b/src/common/literal-syntax.k
@@ -6,7 +6,7 @@ syntax BoolLiteral ::= Bool [klabel('Bool)]
 //syntax Bool ::= true [klabel('True)] todo:"true"?
 
 //@ \subsection{CharacterLiterals.sdf} todo
-syntax SingleChar //::= Token{~[\r\n\'\\]} token not ok
+syntax SingleChar// ::= Token{[\r\n\'\\]}//don't unserstand ^?
 syntax CharContent ::= SingleChar [klabel('Single)]
                      | UnicodeEscape
                      | EscapeSeq
@@ -16,14 +16,13 @@ syntax CharContent ::= SingleChar [klabel('Single)]
 
 syntax EscapeSeq ::= OctaEscape | NamedEscape
 syntax NamedEscape ::= Token{"\\" [btnfr\"\'\\]}         [klabel('NamedEscape)]
-syntax OctaEscape ::= Token{"\\" LastOcta}               [klabel('OctaEscape1)]
+syntax OctaEscape ::= Token{"\\" [0-7]}                  [klabel('OctaEscape1)]
                     | Token{"\\" [0-3][0-7]}             [klabel('OctaEscape2)]
                     | Token{"\\" [4-7][0-7]}             [klabel('OctaEscape2)]
                     | Token{"\\" [0-3][0-7][0-7]}        [klabel('OctaEscape3)]
-syntax LastOcta ::= Token{[0-7]}
-//how to write restrictions?
 
 //@ \subsection{FloatingPointLiterals.sdf} todo
+
 //@ \subsection{IntegerLiterals.sdf}
 //inline token declaration not allowed
 //syntax Ll ::= Token{[lL]?}
@@ -39,5 +38,12 @@ syntax LastOcta ::= Token{[0-7]}
 //syntax IntLiteral ::= DeciLiteral [klabel('Deci)]
 //                    | HexaLiteral [klabel('Hexa)]
 //                    | OctaLiteral [klabel('Octa)]
+
+//@ \subsection{FloatingPointLiterals.sdf} todo
+
+//@ \subsection{NullLiteral.sdf}
+syntax NullLiteral ::= "null" [klabel('Null)]
+
+//@ \subsection{StringLiterals.sdf} todo
 
 endmodule

--- a/src/common/literal-syntax.k
+++ b/src/common/literal-syntax.k
@@ -9,11 +9,11 @@ syntax Bool ::= "true"  [onlyLabel, klabel('True)]
 syntax Bool ::= "false" [onlyLabel, klabel('False)]
 
 //@ \subsection{CharacterLiterals.sdf} todo
-syntax SingleChar// ::= Token{[\r\n\'\\]}//don't unserstand ^?
+syntax SingleChar// ::= Token{[\r\n\'\\]}//don't understand ^?
 syntax CharContent ::= SingleChar [klabel('Single)]
                      | UnicodeEscape
                      | EscapeSeq
-//syntax CharLiteral ::= "'" CharContent "'"  [klabel('Char)]                   Multiple lookahead not fully supported
+syntax CharLiteral //::= "\'" CharContent "\'"  [klabel('Char)]
 
 //@ \subsection{EscapeSequences.sdf}
 
@@ -25,6 +25,7 @@ syntax OctaEscape ::= Token{"\\" [0-7]}                  [klabel('OctaEscape1)]
                     | Token{"\\" [0-3][0-7][0-7]}        [klabel('OctaEscape3)]
 
 //@ \subsection{FloatingPointLiterals.sdf} todo
+syntax FloatLiteral ::= Float      [klabel('Float)]
 
 //@ \subsection{IntegerLiterals.sdf}
 syntax DeciLiteral ::= Token{[1-9][0-9]* [lL]?} [onlyLabel]

--- a/src/common/literal-syntax.k
+++ b/src/common/literal-syntax.k
@@ -27,23 +27,13 @@ syntax OctaEscape ::= Token{"\\" [0-7]}                  [klabel('OctaEscape1)]
 //@ \subsection{FloatingPointLiterals.sdf} todo
 
 //@ \subsection{IntegerLiterals.sdf}
-//inline token declaration not allowed
-//syntax Ll ::= Token{[lL]} cannot define "L"
+syntax DeciLiteral ::= Token{[1-9][0-9]* [lL]?} [onlyLabel]
+syntax HexaLiteral ::= Token{[0][xX] [0-9a-fA-F]+ [lL]?} [onlyLabel]
+syntax OctaLiteral ::= Token{[0]     [0-7]+ [lL]?} [onlyLabel]
 
-//java heap space problem, same code on small language test works
-//syntax DeciNumeral ::=  Token{[1-9][0-9]*} //| "0"
-//syntax DeciLiteral ::= DeciNumeral
-//
-//syntax HexaNumeral ::= Token{[0][xX] [0-9a-fA-F]+}
-//syntax HexaLiteral ::= HexaNumeral
-//
-//syntax OctaNumeral ::= Token{[0]     [0-7]+}
-//syntax OctaLiteral ::= OctaNumeral
-//
-//syntax IntLiteral ::= DeciLiteral [klabel('Deci)]
-//                    | HexaLiteral [klabel('Hexa)]
-//                    | OctaLiteral [klabel('Octa)]
-
+syntax IntLiteral ::= DeciLiteral [klabel('Deci)]
+                    | HexaLiteral [klabel('Hexa)]
+                    | OctaLiteral [klabel('Octa)]
 
 //@ \subsection{NullLiteral.sdf}
 syntax NullLiteral ::= "null" [klabel('Null)]

--- a/src/common/literal-syntax.k
+++ b/src/common/literal-syntax.k
@@ -1,0 +1,43 @@
+require "lexical-syntax.k"
+module LITERAL-SYNTAX
+imports LEXICAL-SYNTAX
+//@ \subsection{BooleanLiterals.sdf} todo
+syntax BoolLiteral ::= Bool [klabel('Bool)]
+//syntax Bool ::= true [klabel('True)] todo:"true"?
+
+//@ \subsection{CharacterLiterals.sdf} todo
+syntax SingleChar //::= Token{~[\r\n\'\\]} token not ok
+syntax CharContent ::= SingleChar [klabel('Single)]
+                     | UnicodeEscape
+                     | EscapeSeq
+//syntax CharLiteral ::= "'" CharContent "'"  [klabel('Char)]                   Multiple lookahead not fully supported
+
+//@ \subsection{EscapeSequences.sdf}
+
+syntax EscapeSeq ::= OctaEscape | NamedEscape
+syntax NamedEscape ::= Token{"\\" [btnfr\"\'\\]}         [klabel('NamedEscape)]
+syntax OctaEscape ::= Token{"\\" LastOcta}               [klabel('OctaEscape1)]
+                    | Token{"\\" [0-3][0-7]}             [klabel('OctaEscape2)]
+                    | Token{"\\" [4-7][0-7]}             [klabel('OctaEscape2)]
+                    | Token{"\\" [0-3][0-7][0-7]}        [klabel('OctaEscape3)]
+syntax LastOcta ::= Token{[0-7]}
+//how to write restrictions?
+
+//@ \subsection{FloatingPointLiterals.sdf} todo
+//@ \subsection{IntegerLiterals.sdf}
+//inline token declaration not allowed
+//syntax Ll ::= Token{[lL]?}
+//
+//syntax DeciNumeral ::=  Token{[1-9][0-9]*} //| "0"
+//syntax DeciLiteral ::= DeciNumeral Ll
+//
+//syntax HexaNumeral ::= Token{[0][xX] [0-9a-fA-F]+}
+//syntax HexaLiteral ::= HexaNumeral Ll
+//syntax OctaNumeral ::= Token{[0]     [0-7]+}
+//syntax OctaLiteral ::= OctaNumeral Ll
+//
+//syntax IntLiteral ::= DeciLiteral [klabel('Deci)]
+//                    | HexaLiteral [klabel('Hexa)]
+//                    | OctaLiteral [klabel('Octa)]
+
+endmodule

--- a/src/common/type-syntax.k
+++ b/src/common/type-syntax.k
@@ -1,0 +1,28 @@
+require "core-sorts.k"
+module TYPE-SYNTAX
+    imports CORE-SORTS
+     //@ \subsection{Types}
+        syntax Type ::= PrimitiveType
+                      | RefType
+                      | "void" [klabel('Void)]
+
+        syntax IntOrLongType ::= "int" [klabel('Int)] | "long" [klabel('Long)]
+        syntax IntType ::= "byte" [klabel('Byte)]| "short" [klabel('Short)]| IntOrLongType | "char" [klabel('Char)]
+        syntax FloatType ::= "float" [klabel('Float)] | "double" [klabel('Double)]
+        syntax NumericType ::= IntType | FloatType
+        syntax PrimitiveType ::= NumericType | "bool" [klabel('Boolean)]
+
+
+    /*@ A fully qualified class name, or noClass where no valid class could be computed.*/
+    syntax ClassType ::= "class" Id
+                       | "noClass"        [latex({\dotCt{K}})]
+
+    /* A reference type is either a class type, an array type, the null type or a String type. The null type is specified
+        by the JLS although inaccessible to the programmer. String objects and types are not threated as regular objects
+        in the present semantics for performance reasons.
+    */
+    syntax RefType ::= ClassType
+                     | "arrayOf" Type
+                     | "nullType"
+
+endmodule

--- a/src/exec/java-exec.k
+++ b/src/exec/java-exec.k
@@ -7,11 +7,7 @@ require "../common/core-classes.k"
 require "../common/core-functions.k"
 require "../common/primitive-types.k"
 require "../common/subtyping.k"
-require "../common/exp-syntax.k"
-require "../common/stmt-syntax.k"
-require "../common/list-syntax.k"
-require "../common/lexical-syntax.k"
-require "../common/literal-syntax.k"
+require "../common/java-syntax.k"
 require "core-exec.k"
 require "syntax-conversions.k"
 require "to-string.k"
@@ -51,13 +47,4 @@ module JAVA-EXEC
    // imports LTL-SUPPORT
     imports JAVA-SYNTAX
 
-endmodule
-
-module JAVA-SYNTAX
-    //imports LTL-SUPPORT-SYNTAX
-    imports LIST-SYNTAX
-    imports STMT-SYNTAX
-    imports EXP-SYNTAX
-    imports LEXICAL-SYNTAX
-    imports LITERAL-SYNTAX
 endmodule

--- a/src/exec/java-exec.k
+++ b/src/exec/java-exec.k
@@ -9,6 +9,9 @@ require "../common/primitive-types.k"
 require "../common/subtyping.k"
 require "../common/exp-syntax.k"
 require "../common/stmt-syntax.k"
+require "../common/list-syntax.k"
+require "../common/lexical-syntax.k"
+require "../common/literal-syntax.k"
 require "core-exec.k"
 require "syntax-conversions.k"
 require "to-string.k"
@@ -55,4 +58,6 @@ module JAVA-SYNTAX
     imports LIST-SYNTAX
     imports STMT-SYNTAX
     imports EXP-SYNTAX
+    imports LEXICAL-SYNTAX
+    imports LITERAL-SYNTAX
 endmodule

--- a/src/prep/java-prep.k
+++ b/src/prep/java-prep.k
@@ -7,11 +7,7 @@ require "../common/core-classes.k"
 require "../common/aux-strings.k"
 require "../common/primitive-types.k"
 require "../common/subtyping.k"
-require "../common/exp-syntax.k"
-require "../common/stmt-syntax.k"
-require "../common/list-syntax.k"
-require "../common/lexical-syntax.k"
-require "../common/literal-syntax.k"
+require "../common/java-syntax.k"
 require "core-preprocessing.k"
 require "process-type-names.k"
 require "process-comp-units.k"
@@ -63,10 +59,4 @@ module JAVA-PREP
 
 endmodule
 
-module JAVA-SYNTAX
-    imports LIST-SYNTAX
-    imports STMT-SYNTAX
-    imports EXP-SYNTAX
-    imports LEXICAL-SYNTAX
-    imports LITERAL-SYNTAX
-endmodule
+

--- a/src/prep/java-prep.k
+++ b/src/prep/java-prep.k
@@ -10,6 +10,8 @@ require "../common/subtyping.k"
 require "../common/exp-syntax.k"
 require "../common/stmt-syntax.k"
 require "../common/list-syntax.k"
+require "../common/lexical-syntax.k"
+require "../common/literal-syntax.k"
 require "core-preprocessing.k"
 require "process-type-names.k"
 require "process-comp-units.k"
@@ -62,7 +64,9 @@ module JAVA-PREP
 endmodule
 
 module JAVA-SYNTAX
-imports LIST-SYNTAX
-imports STMT-SYNTAX
-imports EXP-SYNTAX
+    imports LIST-SYNTAX
+    imports STMT-SYNTAX
+    imports EXP-SYNTAX
+    imports LEXICAL-SYNTAX
+    imports LITERAL-SYNTAX
 endmodule

--- a/src/prep/literals.k
+++ b/src/prep/literals.k
@@ -195,7 +195,6 @@ rule charToString(I:Int :: char) => chrChar(I)
 //@ \subsection{Null literal}
 
 //@ 'Lit('Null(.KList))
-syntax KLabel ::= "'Null"
 rule 'Lit('Null(.KList)) => null
 
 endmodule

--- a/src/prep/literals.k
+++ b/src/prep/literals.k
@@ -133,8 +133,7 @@ rule 'Lit('Bool('False(.KList))) => false
 syntax KLabel ::= "'Single"
 rule 'Lit('Char('Single( I:Int ))) => I :: char
 
-// 'Lit('Char('NamedEscape( Int )))
-syntax KLabel ::= "'NamedEscape"
+// 'Lit('Char('NamedEscape( Int ))
 
 //K bug the three escape characters below are not parsed by K3 in their nice form. Confirmed on 04/03/2014.
 rule 'Lit('Char('NamedEscape(  98 ))) =>                 8 :: char  // \b
@@ -152,9 +151,6 @@ rule 'Lit('Char('NamedEscape(  92 ))) => ordChar("\\") :: char  //"
     'Lit('Char('OctaEscape2( I1:Int,, I2:Int )))
     'Lit('Char('OctaEscape3( I1:Int,, I2:Int,, I3:Int )))
 */
-syntax KLabel ::= "'OctaEscape1"
-                | "'OctaEscape2"
-                | "'OctaEscape3"
 
 rule 'Lit('Char('OctaEscape1( I:Int ))) => octaAsciiToInt(I) :: char
 
@@ -168,7 +164,7 @@ rule 'Lit('Char('OctaEscape3( I1:Int,, I2:Int,, I3:Int )))
      +Int octaAsciiToInt(I3)          :: char
 
 //@ 'Lit('Char('UnicodeEscape(_:K,, I1:Int,, I2:Int,, I3:Int,, I4:Int)))
-syntax KLabel ::= "'UnicodeEscape"
+
 rule 'Lit('Char('UnicodeEscape(_,, I1:Int,, I2:Int,, I3:Int,, I4:Int)))
     =>    hexAsciiToInt(I1) *Int 4096
      +Int hexAsciiToInt(I2) *Int  256

--- a/src/prep/literals.k
+++ b/src/prep/literals.k
@@ -76,9 +76,6 @@ rule hexAsciiToInt(I:Int) => hexDigitToInt(chrChar(I))
 //@ \subsection{Integer literals}
 
 syntax KLabel ::= "'Lit"
-                | "'Deci"
-                | "'Hexa"
-                | "'Octa"
 
 rule [Lit-Deci]:
     'Lit('Deci(Str:String))
@@ -118,9 +115,6 @@ rule [Lit-FFloat]:
 /*@ 'Lit('Bool('True(.KList)))
     'Lit('Bool('False(.KList)))
 */
-syntax KLabel ::= "'Bool"
-                | "'True"
-                | "'False"
 
 rule 'Lit('Bool('True(.KList))) => true
 
@@ -130,7 +124,6 @@ rule 'Lit('Bool('False(.KList))) => false
 //@ Chars are represented as int values, as described in java specification.
 
 //@ 'Lit('Char('Single( I:Int )))
-syntax KLabel ::= "'Single"
 rule 'Lit('Char('Single( I:Int ))) => I :: char
 
 // 'Lit('Char('NamedEscape( Int ))
@@ -174,8 +167,6 @@ rule 'Lit('Char('UnicodeEscape(_,, I1:Int,, I2:Int,, I3:Int,, I4:Int)))
 //@ \subsection{String literals}
 
 //@ 'Lit('String(['Chars(Str:String),, 'NamedEscape(_),, _:KList ]))
-syntax KLabel ::= "'String"
-                | "'Chars"
 
 rule  'Lit('String([K1:K,, K2:K,, Ks:KList]))
       => plusAux( 'Lit('String([K1])),

--- a/src/prep/process-class-members.k
+++ b/src/prep/process-class-members.k
@@ -437,7 +437,7 @@ when
     andBool (getContextType(Modifiers) ==K staticCT)
 
     //condition for not being compile-time constant
-    andBool notBool(        isFinal(Modifiers)
+    andBool notBool(        isFinalModifiers(Modifiers)
                     andBool (getKLabel(InitExp) ==KLabel 'Lit orBool isKResult(InitExp) ==K true)
                    )
         [structural]
@@ -480,7 +480,7 @@ context 'FieldDec(Modifiers:K,, T:Type,, ['VarDec(X:Id,, HOLE) ])
 when
             getContextType(Modifiers) ==K staticCT
     //condition for not being compile-time constant
-    andBool isFinal(Modifiers) andBool getKLabel(HOLE) ==KLabel 'Lit
+    andBool isFinalModifiers(Modifiers) andBool getKLabel(HOLE) ==KLabel 'Lit
 
 rule [FieldDec-compile-time-constant]:
     <k>
@@ -492,7 +492,7 @@ rule [FieldDec-compile-time-constant]:
     <constantEnv> Env:Map => Env[TV/X] </constantEnv>
 when
             getContextType(Modifiers) ==K staticCT
-    andBool isFinal(Modifiers)
+    andBool isFinalModifiers(Modifiers)
 
 /*@ Discard inner class declarations at this phase. They are processed when their
     respective <class> tag is encountered as part of processClasses.
@@ -529,16 +529,16 @@ when        KL =/=KLabel 'Synchronized
 rule isSynchronized([.KList]) => false::bool
 
 //@ Used to provide an approximate implementation of the distinction between static constant and non-constant fields.
-syntax KItem ::=  isFinal (
+syntax KItem ::=  isFinalModifiers (
                 KListWrap   //[...] - the list of method attributes
               )
               [function]
 
-rule isFinal(['Final(_),,_]) => true
+rule isFinalModifiers(['Final(_),,_]) => true
 
-rule isFinal([(KL:KLabel(_) => .KList),, _])
+rule isFinalModifiers([(KL:KLabel(_) => .KList),, _])
 when        KL =/=KLabel 'Final
 
-rule isFinal([.KList])      => false
+rule isFinalModifiers([.KList])      => false
 
 endmodule


### PR DESCRIPTION
In this pull request, I finished my definition for lexical and literal syntax, and delete KLable definitions for klabels I put in attribute. 
Radu will work on this part for parsing purpose later so I skip when there is a problem (especially, when I find it hard to follow exactly IntLiteral, I made floatLiteral very simple).
Also, two small things: I seperated out JAVA-SYNTAX module in a seperate file and use it in both java-exec.k and java-prep.k. Denis used two JAVA-SYNTAX in each independently, but for me, they are the same.
I also sepeated out TYPE-SYNTAX module to be an independent file, which I will continue working on (and create a new branch TypeSyntax).
