### PR TITLE
Kompile java semantics in Java backend

### DIFF
--- a/src/common/core-classes.k
+++ b/src/common/core-classes.k
@@ -9,22 +9,7 @@ module CORE-CLASSES
     imports EXP-SYNTAX //for definitions of sort Exp
     imports STMT-SYNTAX //for definitions of sort Stmt
 
-//@ \subsection{Shortcuts for the most frequently used classes within the semantics}
 
-syntax KItem ::= "classObject"
-    [function, latex(\terminal{Object})]
-rule classObject => class String2Id("java.lang.Object")
-
-syntax KItem ::= "classString"
-    [function, latex(\terminal{String})]
-rule classString => class String2Id("java.lang.String")
-
-syntax KItem ::= "classNullPointerException"
-    [function, latex(\terminal{NullPointerException})]
-rule classNullPointerException => class String2Id("java.lang.NullPointerException")
-
-syntax KItem ::= "classArrayImpl"                   [function]
-rule classArrayImpl => class String2Id("java.lang.ArrayImpl")
 
 //@ \subsection{Packages}
 
@@ -115,18 +100,8 @@ rule isNonNumericExp('CastRef(_)) => true
 //@ Since RawVal terms can easily be converted into TypedVal, they are also of sort Exp.
 syntax Exp ::= TypedVal | RawVal
 
-//@ \subsubsection{Computation terms produced during elaboration}
 
-/*@ These auxiliary terms functions that should be threated as expressions in the elaboration phase.
-*/
-syntax Exp ::= AuxTermExp
-syntax LHS ::= AuxTermExp
-/*@ Wrapper of a statement followed by an expression, to be used in a place where an expression is expected,
-such as an anonymous class declaration. Is typed with the type of the expression.
-At runtime is rewritten into the statement, that should evaluate into .K, followed by the expression,
-that should evaluate to value.*/
-syntax AuxTermExp ::= stmtAndExp ( K, K )
 
-syntax AuxTermExp ::= cast ( Type, K ) [strict] //strictness on 1-st arcument - for runtime produced terms
+
 
 endmodule

--- a/src/common/core-classes.k
+++ b/src/common/core-classes.k
@@ -76,26 +76,6 @@ rule [restoreAfterProcessLocalClass]:
 syntax KItem ::= getConsName ( ClassType )                               [function]
 rule getConsName(class ClassId:Id) => String2Id("$cons$" +String Id2String(ClassId))
 
-//@ \subsection{Expressions and their subsorts}
-syntax Exp ::= NonNumericExp
-syntax NonNumericExp ::= "dummyNonNumericExp"
-
-rule isNonNumericExp('ArrayAccess(_)) => true
-rule isNonNumericExp('NewInstance(_)) => true    // also in customElabChildren
-rule isNonNumericExp('QNewInstance(_)) => true   // also in customElabChildren
-rule isNonNumericExp('InstanceOf(_)) => true
-rule isNonNumericExp('Invoke(_)) => true
-rule isNonNumericExp('This(_)) => true
-rule isNonNumericExp('QThis(_)) => true
-rule isNonNumericExp('AmbName(_)) => true
-rule isNonNumericExp('ExprName(_)) => true
-rule isNonNumericExp('Field(_)) => true
-rule isNonNumericExp('SuperField(_)) => true
-rule isNonNumericExp('QSuperField(_)) => true
-rule isNonNumericExp('NewArray(_)) => true
-rule isNonNumericExp('CastPrim(_)) => true
-rule isNonNumericExp('CastRef(_)) => true
-
 
 //@ Since RawVal terms can easily be converted into TypedVal, they are also of sort Exp.
 syntax Exp ::= TypedVal | RawVal

--- a/src/common/core-functions.k
+++ b/src/common/core-functions.k
@@ -139,14 +139,11 @@ syntax KItem ::=  mapDiff(
                 K   //setWrap(Set)
               )
               [strict]
-
-rule mapDiff( mapWrap( (Key:K |-> _ => .Map) _), setWrap( (SetItem(Key) => .Set) _) )
-
-rule mapDiff( mapWrap( MyMap:Map ), setWrap( (SetItem(Key:K) => .Set) _) )
-when
-    notBool Key in keys(MyMap)
-
-rule mapDiff(mapWrap( MyMap:Map ), setWrap(.Set)) => mapWrap(MyMap)
+//todo
+//rule mapDiff( mapWrap( (Key:K |-> _ => .Map) _:Map), setWrap( (SetItem(Key) => .Set) _:Set) )
+//rule mapDiff( mapWrap( MyMap:Map ), setWrap( (SetItem(Key:K) => .Set) _:Set) )
+//when    notBool Key in keys(MyMap)
+//rule mapDiff(mapWrap( MyMap:Map ), setWrap(.Set)) => mapWrap(MyMap)
 
 syntax KItem ::= isEmpty( Map )   [function]
 rule isEmpty(.Map) => true
@@ -160,12 +157,11 @@ syntax KItem ::=  setUnion (
                 K   //setWrap(Set)
               )
               [strict]
-
-rule setUnion(setWrap( S1:Set (. => SetItem(K)) ), setWrap( S2:Set (SetItem(K:K) => .) ))
-when
-    notBool(K in S1)
-rule setUnion(setWrap( S1:Set SetItem(K) ), setWrap( S2:Set (SetItem(K:K) => .) ))
-rule setUnion(setWrap(S1:Set), setWrap(.Set)) => setWrap(S1)
+//todo use include function
+//rule setUnion(setWrap( S1:Set (.Set => SetItem(K)) ), setWrap( S2:Set (SetItem(K:K) => .Set) ))
+//when    notBool(K in S1)
+//rule setUnion(setWrap( S1:Set SetItem(K) ), setWrap( S2:Set (SetItem(K:K) => .Set) ))
+//rule setUnion(setWrap(S1:Set), setWrap(.Set)) => setWrap(S1)
 
 syntax Set ::= getSet ( K )           [function]
 rule getSet(setWrap(S1:Set)) => S1
@@ -218,7 +214,8 @@ syntax KLabel ::= "'ListWrap"
 rule 'ListWrap(Ks:KList) => [Ks]                  [structural, anywhere]
 //todo: both 'KListWrap and 'ListWrap are associted with the same production, so how to get rid of it
 syntax KListWrap ::= "[" KList "]" [klabel('KListWrap)]
-syntax KItem ::= KListWrap
+syntax UserList ::= KListWrap
+
 //@ Sequence of terms and of any other statements. The first term is moved to the top of computation.
 rule [S1:K,, Stmts:KList] => S1 ~> [Stmts]        [structural]
 rule [.KList] => .K                               [structural]

--- a/src/common/core-functions.k
+++ b/src/common/core-functions.k
@@ -1,7 +1,6 @@
 /*@ \section{Module CORE-FUNCTIONS} */
 module CORE-FUNCTIONS
     imports CORE-SORTS
-    imports CORE-CLASSES
 
 /*@ Returns the type associated with various K terms. The implementation is scattered among various K files.
   For a type - the type itself. For a typed expression - the type component. For some raw values - their most common

--- a/src/common/core-functions.k
+++ b/src/common/core-functions.k
@@ -145,6 +145,18 @@ syntax KItem ::=  mapDiff(
 //when    notBool Key in keys(MyMap)
 //rule mapDiff(mapWrap( MyMap:Map ), setWrap(.Set)) => mapWrap(MyMap)
 
+//@ Substracts from the given map the value given (match is on the value)
+syntax KItem ::= removeMapItemsByValue (Map,K)             [function]
+               | removeMapItemsByValue (Map,K,Map)         [function]
+               | removeMapItemsByValue (K,K,Map,K,Map)     [function]
+
+rule removeMapItemsByValue(M:Map, V:K) => removeMapItemsByValue(M, V, .Map)
+rule removeMapItemsByValue((Key:K |-> Value:K) Remanis:Map, V:K, M:Map) => removeMapItemsByValue(Key, Value, Remanis, V, M)
+rule removeMapItemsByValue(Key:K, V, Remanis:Map, V:K, M:Map) => removeMapItemsByValue(Remanis, V, M)
+rule removeMapItemsByValue(Key:K, Value:K, Remanis:Map, V:K, M:Map) => removeMapItemsByValue(Remanis, V, M (Key |-> Value))
+when Value =/=K V
+rule removeMapItemsByValue(.Map, V:K, M:Map) => M
+
 syntax KItem ::= isEmpty( Map )   [function]
 rule isEmpty(.Map) => true
 

--- a/src/common/core-functions.k
+++ b/src/common/core-functions.k
@@ -157,6 +157,18 @@ rule removeMapItemsByValue(Key:K, Value:K, Remanis:Map, V:K, M:Map) => removeMap
 when Value =/=K V
 rule removeMapItemsByValue(.Map, V:K, M:Map) => M
 
+syntax KItem ::= mapItemsByPartialKey (Map,K)             [function]
+               | mapItemsByPartialKey (Map,K,Map)         [function]
+               | mapItemsByPartialKey (K,K,Map,K,Map)     [function]
+
+rule mapItemsByPartialKey(M:Map, V:K) => mapItemsByPartialKey(M, V, .Map)
+rule mapItemsByPartialKey((Key:K |-> Value:K) Remanis:Map, V:K, M:Map) => mapItemsByPartialKey(Key, Value, Remanis, V, M)
+rule mapItemsByPartialKey(sig(I:Id, T:Types), Value:K, Remanis:Map, I, M:Map)
+     => mapItemsByPartialKey(Remanis, I, M (sig(I,T) |-> Value))
+rule mapItemsByPartialKey(sig(I:Id, T:Types), Value:K, Remanis:Map, V:K, M:Map) => mapItemsByPartialKey(Remanis, V, M)
+when I =/=K V
+rule mapItemsByPartialKey(.Map, V:K, M:Map) => M
+
 syntax KItem ::= isEmpty( Map )   [function]
 rule isEmpty(.Map) => true
 

--- a/src/common/core-functions.k
+++ b/src/common/core-functions.k
@@ -133,27 +133,15 @@ syntax KItem ::=  mapUnion (
 rule mapUnion(mapWrap( M1:Map => M1[K1 <- K2] ), mapWrap( _:Map (K1:K |-> K2:K => .Map) ))
 rule mapUnion(mapWrap(M1:Map), mapWrap(.Map)) => mapWrap(M1)
 
-//@ Substracts fron the given map the keys found in the given set
-syntax KItem ::=  mapDiff(
-                K,  //mapWrap(Map)
-                K   //setWrap(Set)
-              )
-              [strict]
-//todo
-//rule mapDiff( mapWrap( (Key:K |-> _ => .Map) _:Map), setWrap( (SetItem(Key) => .Set) _:Set) )
-//rule mapDiff( mapWrap( MyMap:Map ), setWrap( (SetItem(Key:K) => .Set) _:Set) )
-//when    notBool Key in keys(MyMap)
-//rule mapDiff(mapWrap( MyMap:Map ), setWrap(.Set)) => mapWrap(MyMap)
-
 //@ Substracts from the given map the value given (match is on the value)
 syntax KItem ::= removeMapItemsByValue (Map,K)             [function]
                | removeMapItemsByValue (Map,K,Map)         [function]
                | removeMapItemsByValue (K,K,Map,K,Map)     [function]
 
 rule removeMapItemsByValue(M:Map, V:K) => removeMapItemsByValue(M, V, .Map)
-rule removeMapItemsByValue((Key:K |-> Value:K) Remanis:Map, V:K, M:Map) => removeMapItemsByValue(Key, Value, Remanis, V, M)
-rule removeMapItemsByValue(Key:K, V, Remanis:Map, V:K, M:Map) => removeMapItemsByValue(Remanis, V, M)
-rule removeMapItemsByValue(Key:K, Value:K, Remanis:Map, V:K, M:Map) => removeMapItemsByValue(Remanis, V, M (Key |-> Value))
+rule removeMapItemsByValue((Key:K |-> Value:K) Remains:Map, V:K, M:Map) => removeMapItemsByValue(Key, Value, Remains, V, M)
+rule removeMapItemsByValue(Key:K, V, Remains:Map, V:K, M:Map) => removeMapItemsByValue(Remains, V, M)
+rule removeMapItemsByValue(Key:K, Value:K, Remains:Map, V:K, M:Map) => removeMapItemsByValue(Remains, V, M (Key |-> Value))
 when Value =/=K V
 rule removeMapItemsByValue(.Map, V:K, M:Map) => M
 
@@ -162,10 +150,10 @@ syntax KItem ::= mapItemsByPartialKey (Map,K)             [function]
                | mapItemsByPartialKey (K,K,Map,K,Map)     [function]
 
 rule mapItemsByPartialKey(M:Map, V:K) => mapItemsByPartialKey(M, V, .Map)
-rule mapItemsByPartialKey((Key:K |-> Value:K) Remanis:Map, V:K, M:Map) => mapItemsByPartialKey(Key, Value, Remanis, V, M)
-rule mapItemsByPartialKey(sig(I:Id, T:Types), Value:K, Remanis:Map, I, M:Map)
-     => mapItemsByPartialKey(Remanis, I, M (sig(I,T) |-> Value))
-rule mapItemsByPartialKey(sig(I:Id, T:Types), Value:K, Remanis:Map, V:K, M:Map) => mapItemsByPartialKey(Remanis, V, M)
+rule mapItemsByPartialKey((Key:K |-> Value:K) Remains:Map, V:K, M:Map) => mapItemsByPartialKey(Key, Value, Remains, V, M)
+rule mapItemsByPartialKey(sig(I:Id, T:Types), Value:K, Remains:Map, I, M:Map)
+     => mapItemsByPartialKey(Remains, I, M (sig(I,T) |-> Value))
+rule mapItemsByPartialKey(sig(I:Id, T:Types), Value:K, Remains:Map, V:K, M:Map) => mapItemsByPartialKey(Remains, V, M)
 when I =/=K V
 rule mapItemsByPartialKey(.Map, V:K, M:Map) => M
 
@@ -181,11 +169,7 @@ syntax KItem ::=  setUnion (
                 K   //setWrap(Set)
               )
               [strict]
-//todo use include function
-//rule setUnion(setWrap( S1:Set (.Set => SetItem(K)) ), setWrap( S2:Set (SetItem(K:K) => .Set) ))
-//when    notBool(K in S1)
-//rule setUnion(setWrap( S1:Set SetItem(K) ), setWrap( S2:Set (SetItem(K:K) => .Set) ))
-//rule setUnion(setWrap(S1:Set), setWrap(.Set)) => setWrap(S1)
+rule setUnion(setWrap(S1:Set), setWrap(S2:Set)) => setWrap(S1 S2)
 
 syntax Set ::= getSet ( K )           [function]
 rule getSet(setWrap(S1:Set)) => S1

--- a/src/common/core-functions.k
+++ b/src/common/core-functions.k
@@ -1,6 +1,37 @@
 /*@ \section{Module CORE-FUNCTIONS} */
 module CORE-FUNCTIONS
     imports CORE-SORTS
+    imports AUX-STRINGS
+
+//@ \subsection{Shortcuts for the most frequently used classes within the semantics}
+
+syntax KItem ::= "classObject"
+    [function, latex(\terminal{Object})]
+rule classObject => class String2Id("java.lang.Object")
+
+syntax KItem ::= "classString"
+    [function, latex(\terminal{String})]
+rule classString => class String2Id("java.lang.String")
+
+syntax KItem ::= "classNullPointerException"
+    [function, latex(\terminal{NullPointerException})]
+rule classNullPointerException => class String2Id("java.lang.NullPointerException")
+
+syntax KItem ::= "classArrayImpl"                   [function]
+rule classArrayImpl => class String2Id("java.lang.ArrayImpl")
+
+//@ \subsubsection{Computation terms produced during elaboration}
+/*@ These auxiliary terms functions that should be threated as expressions in the elaboration phase.
+*/
+syntax Exp ::= AuxTermExp
+syntax LHS ::= AuxTermExp
+/*@ Wrapper of a statement followed by an expression, to be used in a place where an expression is expected,
+such as an anonymous class declaration. Is typed with the type of the expression.
+At runtime is rewritten into the statement, that should evaluate into .K, followed by the expression,
+that should evaluate to value.*/
+syntax AuxTermExp ::= stmtAndExp ( K, K )
+
+syntax AuxTermExp ::= cast ( Type, K ) [strict] //strictness on 1-st arcument - for runtime produced terms
 
 /*@ Returns the type associated with various K terms. The implementation is scattered among various K files.
   For a type - the type itself. For a typed expression - the type component. For some raw values - their most common
@@ -99,7 +130,7 @@ syntax KItem ::=  mapUnion (
               )
               [strict]
 
-rule mapUnion(mapWrap( M1:Map => M1[K2/K1] ), mapWrap( _:Map (K1:K |-> K2:K => .Map) ))
+rule mapUnion(mapWrap( M1:Map => M1[K1 <- K2] ), mapWrap( _:Map (K1:K |-> K2:K => .Map) ))
 rule mapUnion(mapWrap(M1:Map), mapWrap(.Map)) => mapWrap(M1)
 
 //@ Substracts fron the given map the keys found in the given set
@@ -187,7 +218,7 @@ syntax KLabel ::= "'ListWrap"
 rule 'ListWrap(Ks:KList) => [Ks]                  [structural, anywhere]
 //todo: both 'KListWrap and 'ListWrap are associted with the same production, so how to get rid of it
 syntax KListWrap ::= "[" KList "]" [klabel('KListWrap)]
-
+syntax KItem ::= KListWrap
 //@ Sequence of terms and of any other statements. The first term is moved to the top of computation.
 rule [S1:K,, Stmts:KList] => S1 ~> [Stmts]        [structural]
 rule [.KList] => .K                               [structural]

--- a/src/common/core-sorts.k
+++ b/src/common/core-sorts.k
@@ -200,8 +200,8 @@ syntax ClassOrName ::= Id | ClassType
 //Denis' syntax
 syntax ClassType ::= "class" Id | "noClass"                     [latex({\dotCt{K}})]
 //Denis' syntax
-syntax Param ::= Type Id                                            [klabel('ParamImpl)]
-
+syntax ParamImpl ::= Type Id                                            [klabel('ParamImpl)]
+syntax Param ::= ParamImpl
 /* Denis' syntax: A reference type is either a class type, an array type, the null type or a String type.
 The null type is specified by the JLS although inaccessible to the programmer. String objects and
 types are not threated as regular objects in the present semantics for performance reasons.

--- a/src/common/core-sorts.k
+++ b/src/common/core-sorts.k
@@ -1,11 +1,6 @@
-require "lexical-syntax.k"
-require "literal-syntax.k"
-require "type-syntax.k"
 //@ \section{Module CORE-SORTS}
 module CORE-SORTS
     imports TYPE-SYNTAX
-    imports LEXICAL-SYNTAX
-    imports LITERAL-SYNTAX
 
 //@ \subsection{Computation phases}
 

--- a/src/common/list-syntax.k
+++ b/src/common/list-syntax.k
@@ -71,6 +71,8 @@ syntax UserList     ::= BlockStmList
                       | StringPartList
                       | EnumConstList
                       | ClassBodyDecList
+                      | Params
+
 
 
 endmodule

--- a/src/common/primitive-types.k
+++ b/src/common/primitive-types.k
@@ -1,7 +1,5 @@
 //@ \section{Module PRIMITIVE-TYPES}
-
 module PRIMITIVE-TYPES
-    imports CORE-SORTS
     imports SUBTYPING
 
 //@ \subsection{Integer types normalization}

--- a/src/common/primitive-types.k
+++ b/src/common/primitive-types.k
@@ -87,7 +87,7 @@ when (IT =/=K int) andBool (IT =/=K long)
 
 /*@ Important! Binary normalizeType cannot be function because it uses sybtype in implementation.
 */
-syntax KItem ::= normalizeType ( Type, Type )
+syntax KItem ::= normalizeType ( Type, Type )   [function]
 
 rule normalizeType(NT1:IntType, NT2:IntType) => int
 when (NT1 =/=K long) andBool (NT2 =/=K long)

--- a/src/common/primitive-types.k
+++ b/src/common/primitive-types.k
@@ -29,7 +29,7 @@ rule normalize(I:Int :: char)
           toUnsigned(normalizeImpl(I::char))
         )
 
-rule normalize(I:Int :: FloatT:FloatType) => Int2Float(I)::FloatT
+rule normalize(I:Int :: FloatT:FloatType) => Int2Float(I,53,11)::FloatT
 
 rule normalize(F:Float :: IntT:IntType) => normalize(Float2Int(F) :: IntT:IntType)
 

--- a/src/common/subtyping.k
+++ b/src/common/subtyping.k
@@ -1,5 +1,4 @@
 //@ \section{Module SUBTYPING}
-
 module SUBTYPING
     imports CORE-SORTS
     imports CORE-CLASSES

--- a/src/exec/api-core.k
+++ b/src/exec/api-core.k
@@ -72,11 +72,11 @@ syntax KItem ::=  "readInt"
 
 rule [readInt]:
     <k> readInt => I :: int ...</k>
-    <in> ListItem(I:Int) => . ...</in>
+    <in> ListItem(I:Int) => .List ...</in>
 
 rule [readString]:
     <k> readString => Str :: classString ...</k>
-    <in> ListItem(Str:String) => . ...</in>
+    <in> ListItem(Str:String) => .List ...</in>
 
 /*@ object.getClass()*/
 rule [object-getClass-on-object]:

--- a/src/exec/api-core.k
+++ b/src/exec/api-core.k
@@ -30,7 +30,7 @@ rule [system-out-print-string]:
       ) => nothing::void
       ...
     </k>
-    <out>... . => ListItem(Str) </out>
+    <out>... .List => ListItem(Str) </out>
 when
     Class ==K class String2Id("java.io.PrintWriter") andBool Id2String(MethodName) ==String "print"
 
@@ -264,11 +264,11 @@ rule [storeCopy-discard]:
 */
 rule [Lit-Class-Instantiate]:
     <k>
-        (. => saveClassLiteral(T, new class String2Id("java.lang.Class") (toString(T)) ) )
+        (.K => saveClassLiteral(T, new class String2Id("java.lang.Class") (toString(T)) ) )
         ~> 'Lit('Class(T:Type))
       ...
     </k>
-    <classLiteralsMap> CLMap:Map (. => T |-> temp) </classLiteralsMap>
+    <classLiteralsMap> CLMap:Map (.Map => T |-> temp) </classLiteralsMap>
 when notBool T in keys(CLMap)
         [transition-threading]
 

--- a/src/exec/api-threads.k
+++ b/src/exec/api-threads.k
@@ -4,7 +4,6 @@ module API-THREADS
     imports CORE-SORTS
     imports METHOD-INVOKE-REST  //for invokeImpl
     imports VAR-LOOKUP          //for typedLookup
-    imports API-THREADS-SELECTION
 
 /*@Java API related to threads and locks. Just the core part.*/
 
@@ -286,10 +285,6 @@ rule [DissolveAllExceptOut]:
     </T>
     => <T> <out> Out </out> </T>
 
-endmodule
-
-module API-THREADS-SELECTION
-    imports API-THREADS
 
 //@ \section{Methods wait() and notify()}
 

--- a/src/exec/api-threads.k
+++ b/src/exec/api-threads.k
@@ -49,8 +49,8 @@ rule [Synchronized-first-time]:
           => try Block .CatchClauses finally releaseLock(OId)
           ...
     </k>
-    <holds>... (. => OId |-> 1) ...</holds>
-    <busy> Busy:Set (. => SetItem(OId)) </busy>
+    <holds>... (.Map => OId |-> 1) ...</holds>
+    <busy> Busy:Set (.Set => SetItem(OId)) </busy>
 when
     notBool (OId in Busy)
         [transition-threading, transition-sync]
@@ -87,9 +87,10 @@ K performance evaluation with the rule below active and commented:
 
   Conclusion: the rule below have no impact on performance.
 */
-rule [monitor-completely-released]:
-    <holds>... (OL:Int |-> 0 => .) ...</holds>
-    <busy>... (SetItem(OL) => .) ...</busy>
+//todo mapItemByValue
+//rule [monitor-completely-released]:
+//    <holds>... (OL:Int |-> 0 => .Map) ...</holds>
+//    <busy>... (SetItem(OL) => .Set) ...</busy>
 
 //@ \subsection{Thread.join()}
 
@@ -152,7 +153,7 @@ rule [waitImpl-interrupted]:
       ...
     </k>
     <tid> TId:Int </tid>
-    <busy> Busy:Set (. => SetItem(OL)) </busy>
+    <busy> Busy:Set (.Set => SetItem(OL)) </busy>
     <interrupted> true => false </interrupted>
 when
       notBool OL in Busy
@@ -165,13 +166,14 @@ syntax KItem ::=  notifyImpl (
                 Int //store key of the monitor object
               )
 
-rule [notifyImpl-someone-waiting]:
-    <k>
-      notifyImpl(OL:Int) => nothing::void
-      ...
-    </k>
-    <waitingThreads>... (_ |-> OL => .Map) ...</waitingThreads>
-        [transition-threading]
+//todo mapItemByValue
+//rule [notifyImpl-someone-waiting]:
+//    <k>
+//      notifyImpl(OL:Int) => nothing::void
+//      ...
+//    </k>
+//    <waitingThreads>... (_ |-> OL => .Map) ...</waitingThreads>
+//        [transition-threading]
 
 rule [notifyImpl-no-one-waiting]:
     <k>
@@ -199,14 +201,14 @@ when
 syntax KItem ::=  objectNotifyAllImpl (
                 Int //store key of the monitor object
               )
-
-rule [objectNotifyAllImpl-someone-waiting]:
-    <k>
-      objectNotifyAllImpl(OL:Int)
-      ...
-    </k>
-    <waitingThreads>... (_ |-> OL => .Map) ...</waitingThreads>
-        [transition-threading]
+//todo mapItemByValue
+//rule [objectNotifyAllImpl-someone-waiting]:
+//    <k>
+//      objectNotifyAllImpl(OL:Int)
+//      ...
+//    </k>
+//    <waitingThreads>... (_ |-> OL => .Map) ...</waitingThreads>
+//        [transition-threading]
 
 rule [objectNotifyAllImpl-no-one-waiting]:
     <k>
@@ -267,7 +269,7 @@ rule [ThreadTermination]:
       </thread>
     => .)
     <busy> Busy:Set => Busy -Set keys(H) </busy>
-    <terminated>... . => SetItem(TId) ...</terminated>
+    <terminated>... .Set => SetItem(TId) ...</terminated>
     <globalPhase> ExecutionPhase </globalPhase>
     <dissolveEmptyK> false </dissolveEmptyK>
 
@@ -315,8 +317,8 @@ rule [object-wait]:
       <holds>... OId |-> HoldLevel:Int ...</holds>
       ...
     </thread>
-    <busy>... (SetItem(OId) => .) ...</busy>
-    <waitingThreads>... (. => TId |-> OId ) ...</waitingThreads>
+    <busy>... (SetItem(OId) => .Set) ...</busy>
+    <waitingThreads>... (.Map => TId |-> OId ) ...</waitingThreads>
 when
             Class ==K classObject
     andBool Id2String(Method) ==String "wait"
@@ -347,10 +349,11 @@ Here we present the rule for the first case. If there is a thread waiting on the
   associated to that value we enable the waiting thread to proceed. If there is no thread waiting for this object then
   the term \verb|notifyImpl()| is simply consumed.
 */
-rule [notifyImpl-someone-waiting]:
-    <k> notifyImpl(OId:Int) => nothing::void ...</k>
-    <waitingThreads>... (_ |-> OId => .Map) ...</waitingThreads>
-        [transition-threading]
+//todo mapItemByValue
+//rule [notifyImpl-someone-waiting]:
+//    <k> notifyImpl(OId:Int) => nothing::void ...</k>
+//    <waitingThreads>... (_ |-> OId => .Map) ...</waitingThreads>
+//        [transition-threading]
 
 /*@
 At this stage the rule for \verb|waitImpl()| could match. The rule checks in its side conditions that the current
@@ -362,7 +365,7 @@ At this stage the rule for \verb|waitImpl()| could match. The rule checks in its
 rule [waitImpl-main]:
     <k> waitImpl(OId:Int) => nothing::void ...</k>
     <tid> TId:Int </tid>
-    <busy> Busy:Set (. => SetItem(OId)) </busy>
+    <busy> Busy:Set (.Set => SetItem(OId)) </busy>
     <interrupted> false </interrupted>
     <waitingThreads> WT:Map </waitingThreads>
 when

--- a/src/exec/api-threads.k
+++ b/src/exec/api-threads.k
@@ -87,10 +87,13 @@ K performance evaluation with the rule below active and commented:
 
   Conclusion: the rule below have no impact on performance.
 */
-//todo mapItemByValue
+//todo mapItemByValue/solution
 //rule [monitor-completely-released]:
 //    <holds>... (OL:Int |-> 0 => .Map) ...</holds>
 //    <busy>... (SetItem(OL) => .Set) ...</busy>
+rule [monitor-completely-released]:
+    <holds> M:Map => removeMapItemsByValue(M,0) </holds>
+    <busy> S:Set => S -Set keys(M -Map removeMapItemsByValue(M,0)) </busy>
 
 //@ \subsection{Thread.join()}
 
@@ -166,14 +169,14 @@ syntax KItem ::=  notifyImpl (
                 Int //store key of the monitor object
               )
 
-//todo mapItemByValue
-//rule [notifyImpl-someone-waiting]:
-//    <k>
-//      notifyImpl(OL:Int) => nothing::void
-//      ...
-//    </k>
-//    <waitingThreads>... (_ |-> OL => .Map) ...</waitingThreads>
-//        [transition-threading]
+//todo mapItemByValue/solution
+rule [notifyImpl-someone-waiting]:
+    <k>
+      notifyImpl(OL:Int) => nothing::void
+      ...
+    </k>
+    <waitingThreads> M:Map => removeMapItemsByValue(M,OL) </waitingThreads>
+        [transition-threading]
 
 rule [notifyImpl-no-one-waiting]:
     <k>
@@ -201,14 +204,14 @@ when
 syntax KItem ::=  objectNotifyAllImpl (
                 Int //store key of the monitor object
               )
-//todo mapItemByValue
-//rule [objectNotifyAllImpl-someone-waiting]:
-//    <k>
-//      objectNotifyAllImpl(OL:Int)
-//      ...
-//    </k>
-//    <waitingThreads>... (_ |-> OL => .Map) ...</waitingThreads>
-//        [transition-threading]
+//todo mapItemByValue/solution
+rule [objectNotifyAllImpl-someone-waiting]:
+    <k>
+      objectNotifyAllImpl(OL:Int)
+      ...
+    </k>
+    <waitingThreads> M:Map => removeMapItemsByValue(M,OL) </waitingThreads>
+        [transition-threading]
 
 rule [objectNotifyAllImpl-no-one-waiting]:
     <k>
@@ -349,11 +352,11 @@ Here we present the rule for the first case. If there is a thread waiting on the
   associated to that value we enable the waiting thread to proceed. If there is no thread waiting for this object then
   the term \verb|notifyImpl()| is simply consumed.
 */
-//todo mapItemByValue
-//rule [notifyImpl-someone-waiting]:
-//    <k> notifyImpl(OId:Int) => nothing::void ...</k>
-//    <waitingThreads>... (_ |-> OId => .Map) ...</waitingThreads>
-//        [transition-threading]
+//todo mapItemByValue/solution
+rule [notifyImpl-someone-waiting]:
+    <k> notifyImpl(OId:Int) => nothing::void ...</k>
+    <waitingThreads> M:Map => removeMapItemsByValue(M,OId) </waitingThreads>
+        [transition-threading]
 
 /*@
 At this stage the rule for \verb|waitImpl()| could match. The rule checks in its side conditions that the current

--- a/src/exec/arrays.k
+++ b/src/exec/arrays.k
@@ -153,8 +153,8 @@ syntax KItem ::=  allocArray (
 
 rule [allocArray]:
     <k> allocArray(N:Int => N -Int 1, T:Type) ...</k>
-    <store>... . => LI |-> (undefined :: elem T) ...</store>
-    <storeMetadata>... . => LI |-> FieldLocMetadata ...</storeMetadata>
+    <store>... .Map => LI |-> (undefined :: elem T) ...</store>
+    <storeMetadata>... .Map => LI |-> FieldLocMetadata ...</storeMetadata>
     <nextLoc> LI:Int => LI +Int 1 </nextLoc>
 when
     N >Int 0

--- a/src/exec/configuration-exec.k
+++ b/src/exec/configuration-exec.k
@@ -37,7 +37,7 @@ configuration
             //Thread Id
             <tid color="BlueViolet"> 0 </tid>
 
-            //Map[OL |-> Count] - the amount of times this thread holds the monitor objects referred bu the keys
+            //Map[OL |-> Count] - the amount of times this thread holds the monitor objects referred by the keys
             <holds color="BlueViolet"> .Map </holds>
 
             //Whether this thread was interrupted by another thread by a call to Thread.interrupt()

--- a/src/exec/configuration-exec.k
+++ b/src/exec/configuration-exec.k
@@ -106,7 +106,7 @@ configuration
                 <methodSignature color="Blue"> .K </methodSignature>
 
                 //Method params
-                <methodParams color="Blue"> ([.KList]):KItem </methodParams>
+                <methodParams color="Blue"> [.KList]:>UserList </methodParams>
                 <br/>
 
                 //Method body

--- a/src/exec/configuration-exec.k
+++ b/src/exec/configuration-exec.k
@@ -106,7 +106,7 @@ configuration
                 <methodSignature color="Blue"> .K </methodSignature>
 
                 //Method params
-                <methodParams color="Blue"> [.KList] </methodParams>
+                <methodParams color="Blue"> ([.KList]):KItem </methodParams>
                 <br/>
 
                 //Method body

--- a/src/exec/core-exec.k
+++ b/src/exec/core-exec.k
@@ -2,7 +2,6 @@
 
 module CORE-EXEC
     imports CORE-SORTS
-    imports SYNTAX-CONVERSIONS
 
 //@ ListItem content as a stack layer
 syntax KItem ::=  sl (

--- a/src/exec/expressions.k
+++ b/src/exec/expressions.k
@@ -83,12 +83,12 @@ rule /* F1 % F2 */ F1:Float :: _ % F2:Float :: _ => (F1 %Float F2) :: tempType
 rule _:TypedVal % 0::_ => throw new class String2Id("java.lang.ArithmeticException") ("/ by zero");
 
 rule [NormalizeLeftOperandToFloat]:
-    KL:KLabel((I:Int::_:IntType => Int2Float(I)::float),, _:Float :: _:FloatType)
+    KL:KLabel((I:Int::_:IntType => Int2Float(I,53,11)::float),, _:Float :: _:FloatType)
 when
     isFloatBinaryOp(KL)
 
 rule [NormalizeRightOperandToFloat]:
-    KL:KLabel(_:Float :: _:FloatType,, (I:Int::_:IntType => Int2Float(I)::float))
+    KL:KLabel(_:Float :: _:FloatType,, (I:Int::_:IntType => Int2Float(I,53,11)::float))
 when
     isFloatBinaryOp(KL)
 
@@ -119,7 +119,7 @@ rule /* ~ I    */ ~ I:Int :: _ => (~Int I) :: tempType
 rule /* + I    */ + I:Int :: _ => I :: tempType
 rule /* + F    */ + F:Float :: _ => F :: tempType
 rule /* - I    */ - I:Int :: _ => (0 -Int I) :: tempType
-rule /* - F    */ - F:Float :: _ => (Int2Float(0) -Float F) :: tempType
+rule /* - F    */ - F:Float :: _ => (Int2Float(0,53,11) -Float F) :: tempType
 
 // E++
 rule /* loc(L)++ => (loc(L) = lookup(L) + 1) - 1 */
@@ -133,7 +133,7 @@ rule /* loc(L)-- => (loc(L) = lookup(L) - 1) + 1 */
 Int when NT is IntType, Float when NT is FloatType*/
 syntax KItem ::= rightTypedNumber ( Int, NumericType )             [function]
 rule rightTypedNumber(I:Int, IntT:IntType) => I::IntT
-rule rightTypedNumber(I:Int, FloatT:FloatType) => Int2Float(I)::FloatT
+rule rightTypedNumber(I:Int, FloatT:FloatType) => Int2Float(I,53,11)::FloatT
 
 /*@ Conditional expression : ?: . Desugared into an if with cast.
 The biggest difficulty is computing the expression type, according to JLS1 \$15.24

--- a/src/exec/method-invoke.k
+++ b/src/exec/method-invoke.k
@@ -728,18 +728,18 @@ The return statement at the end ensures that there is a return statement on ever
 */
 rule [Invoke-methodRef]:
     <k>
-      Qual:KResult . methodRef(Sig:Signature, DecC:ClassType) (Args:TypedVals) ~> RestK:K
-      => staticInit(DecC) ~> initParams(Params, Args) ~> Body ~> return ('Some(nothing :: void)) ;
+      (Qual:KResult . methodRef(Sig:Signature, DecC:ClassType) (Args:TypedVals) ~> RestK:K
+      => staticInit(DecC) ~> initParams(Params, Args) ~> Body ~> return ('Some(nothing :: void)) ;)
     </k>
     <stack>
-      . => ListItem(sl(RestK, MethodContext))
+      .List => ListItem(sl(RestK, MethodContext))
       ...
     </stack>
     <methodContext>
-      MethodContext:Bag
+      (MethodContext:Bag
       =>  <env> .Map </env>
           <crntClass> DecC </crntClass>
-          <location> getOId(Qual) </location>
+          <location> getOId(Qual) </location>)
     </methodContext>
 
     <classType> DecC </classType>

--- a/src/exec/new-instance.k
+++ b/src/exec/new-instance.k
@@ -4,6 +4,7 @@ module NEW-INSTANCE
     imports CORE-EXEC   //for sl, restoreMethContext
     imports STATIC-INIT // for staticInit
     imports VAR-LOOKUP  //for typedLookup()
+    imports SYNTAX-CONVERSIONS  //for toExps()
 
 /*@
 \section{Module NEW-INSTANCE}

--- a/src/exec/new-instance.k
+++ b/src/exec/new-instance.k
@@ -157,7 +157,7 @@ rule [qualified-new-instance]:
         ~> typedLookup(L)
       ...
     </k>
-    <store>... . => L |-> objectRef(L, Class) :: Class ...</store>
+    <store>... .Map => L |-> objectRef(L, Class) :: Class ...</store>
     <nextLoc> L:Int => L +Int 1 </nextLoc>
     (.Bag =>  <object>
                 <objectId> L </objectId>
@@ -170,7 +170,7 @@ rule [qualified-new-instance]:
           <crntClass> .K </crntClass>
           <location> L </location>
     </methodContext>
-    <storeMetadata>... . => L |-> LocalLocMetadata ...</storeMetadata>
+    <storeMetadata>... .Map => L |-> LocalLocMetadata ...</storeMetadata>
 
 syntax KItem ::=  create ( ClassType )
 
@@ -253,9 +253,9 @@ module NEW-INSTANCE-REST
 
 rule [FieldDec-instance]:
     <k> 'FieldDec([.KList],, T:Type,,['VarDec(X:Id)]) => . ...</k>
-    <env> Env:Map => Env[L/X] </env>
-    <store>... . => L |-> default(T) ...</store>
-    <storeMetadata>... . => L |-> FieldLocMetadata ...</storeMetadata>
+    <env> Env:Map => Env[X <- L] </env>
+    <store>... .Map => L |-> default(T) ...</store>
+    <storeMetadata>... .Map => L |-> FieldLocMetadata ...</storeMetadata>
     <nextLoc> L:Int => L +Int 1 </nextLoc>
 
 //@\subsection{Execution of QSuperConstrInv, AltConstrInv}

--- a/src/exec/statements.k
+++ b/src/exec/statements.k
@@ -8,6 +8,7 @@ module STATEMENTS
     imports VAR-LOOKUP
     imports METHOD-INVOKE // for initParams
     imports STMT-SYNTAX
+    imports TO-STRING
 
 //@ \subsection{isStmt}
 rule isStmt('For(_)) => true

--- a/src/exec/statements.k
+++ b/src/exec/statements.k
@@ -328,14 +328,14 @@ when
 rule [Return-MethodEnd]:
 //    <k> 'Return('Some(TV:TypedVal)) => TV ~> K </k>
     <k> return 'Some(TV:TypedVal); => TV ~> K </k>
-    <stack> ListItem( sl(K:K, MethContext:Bag) ) => . ...</stack>
+    <stack> ListItem( sl(K:K, MethContext:Bag) ) => .List ...</stack>
     <methodContext> _:Bag => MethContext </methodContext>
 
 /*@ \subsection{Throw statement}
 Exceptions are propagated now until a catch that can bind them is
 encountered. */
 rule [Throw]:
-    (. => checkCatch(subtype(typeOf(TV), T)))
+    (.K => checkCatch(subtype(typeOf(TV), T)))
 //    ~> 'Throw(TV:TypedVal)
     ~> throw TV:TypedVal;
     ~> catchBlocks(catchImpl('ParamImpl(T:Type,, X:Id),_) _:CatchClauses)
@@ -376,7 +376,7 @@ rule [Throw-MethodEnd]:
 //      'Throw(TV:TypedVal) ~> (. => K)
       throw TV:TypedVal; ~> (. => K)
     </k>
-    <stack> ListItem( sl(K:K, MethContext:Bag) ) => . ...</stack>
+    <stack> ListItem( sl(K:K, MethContext:Bag) ) => .List ...</stack>
     <methodContext> _ => MethContext </methodContext>
 
 rule [Throw-CausesThreadTermination]:
@@ -423,11 +423,10 @@ rule catch(KR:ExtKResult)S:K => catchImpl(KR,S)
 /*@ Extended K Result.
   Represents KLabels that should be treated as KResult during execution phase, but not during elaboration phase.
 */
-syntax ExtKResult ::= "dummy"
+syntax ExtKResult ::= ParamImpl
 
 rule isExtKResult(KR:KResult) => true
 
-rule isExtKResult('ParamImpl(T:Type,, _:Id)) => true
 
 //@ Internal representation of a preprocessed catch clause
 syntax CatchImpl ::=  catchImpl (

--- a/src/exec/statements.k
+++ b/src/exec/statements.k
@@ -55,9 +55,9 @@ rule [env-double-Discard]:
 
 rule [LocalVarDec]:
     <k> T:Type X:Id; => . ...</k>
-    <env> Env:Map => Env[L/X] </env>
-    <store>... . => L |-> default(T) ...</store>
-    <storeMetadata>... . => L |-> LocalLocMetadata ...</storeMetadata>
+    <env> Env:Map => Env[X <- L] </env>
+    <store>... .Map => (L |-> default(T)) ...</store>
+    <storeMetadata>... .Map => (L |-> LocalLocMetadata) ...</storeMetadata>
     <nextLoc> L:Int => L +Int 1 </nextLoc>
 
 //@ \subsection{Empty statement} JLS \$14.6

--- a/src/exec/static-init.k
+++ b/src/exec/static-init.k
@@ -109,8 +109,8 @@ rule [FieldDec-static]:
     <crntClass> Class:ClassType </crntClass>
     <classType> Class </classType>
     <staticEnv> Env:Map => Env[L/X] </staticEnv>
-    <store>... . => L |-> default(T) ...</store>
-    <storeMetadata>... . => L |-> FieldLocMetadata ...</storeMetadata>
+    <store>... .Map => L |-> default(T) ...</store>
+    <storeMetadata>... .Map => L |-> FieldLocMetadata ...</storeMetadata>
     <nextLoc> L:Int => L +Int 1 </nextLoc>
 
 endmodule

--- a/src/exec/static-init.k
+++ b/src/exec/static-init.k
@@ -40,7 +40,7 @@ rule [staticInit]:
               [
                 'Catch('ParamImpl(classObject,, String2Id("e") ),,
                 'Block(throw new class String2Id("java.lang.ExceptionInInitializerError")
-                (((classObject) String2Id("e")));))
+                (((class String2Id("java.lang.Object")) String2Id("e")));))
               ]
             ,,
 

--- a/src/exec/syntax-conversions.k
+++ b/src/exec/syntax-conversions.k
@@ -6,6 +6,7 @@ module SYNTAX-CONVERSIONS
     imports CORE-SORTS
     imports CORE-FUNCTIONS
     imports CORE-CLASSES    //for cast
+    imports CORE-EXEC
 
 /*@ \subsection{Method parameter}*/
 

--- a/src/exec/syntax-conversions.k
+++ b/src/exec/syntax-conversions.k
@@ -12,7 +12,7 @@ module SYNTAX-CONVERSIONS
 
 // 'Param(\_:K,, T:Type,, X:Id). Consumed by initParams().
 
-syntax KItem ::= toParams( KListWrap )          [function]
+syntax Params ::= toParams( KListWrap )          [function]
            | toParams( KListWrap , Params ) [function]
 
 rule toParams([KLParams:KList]) => toParams([KLParams], .Params)

--- a/src/exec/syntax-conversions.k
+++ b/src/exec/syntax-conversions.k
@@ -6,7 +6,6 @@ module SYNTAX-CONVERSIONS
     imports CORE-SORTS
     imports CORE-FUNCTIONS
     imports CORE-CLASSES    //for cast
-    imports CORE-EXEC
 
 /*@ \subsection{Method parameter}*/
 

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -69,8 +69,8 @@ rule toString(objectRef(OId:Int, LowestClass:ClassType) :: T:Type)
 //@ \subsection{Debug helper functions}
 
 syntax KItem ::= debugPrint ( K )                [strict]
-rule <k> debugPrint(Str:String::_) => . ...</k>
-     <out>... . => ListItem(Str +String "\n") </out>
+rule <k> debugPrint(Str:String::_) => .K ...</k>
+     <out>... .List => ListItem(Str +String "\n") </out>
 
 syntax KItem ::= debugString( K )             [function]
            | debugStringList( KListWrap ) [function]

--- a/src/exec/unfolding.k
+++ b/src/exec/unfolding.k
@@ -3,6 +3,7 @@ module UNFOLDING
     imports CORE-FUNCTIONS
     imports SYNTAX-CONVERSIONS
 
+
 rule [UnfoldingPhase-start]:
     <k> . => unfoldingPhase </k>
     <globalPhase> FoldingPhase => UnfoldingPhase </globalPhase>
@@ -158,7 +159,8 @@ rule [unfolding-MethodDec]:
       )
       ...
     </methodDecs>
-    <methods> Env:Map => Env[Class / sig(Name:Id, getTypes([Params]))] </methods>
+    //todo
+    <methods> Env:Map => Env[sig(Name:Id, getTypes([Params])) <- Class] </methods>
     <folded>
       _:KLabel(
         'ClassDecHead(_),,

--- a/src/exec/var-lookup.k
+++ b/src/exec/var-lookup.k
@@ -4,7 +4,6 @@ module VAR-LOOKUP
     imports CORE-SORTS
     imports SUBTYPING
     imports STATIC-INIT         //for staticInit()
-    imports EXPRESSIONS
 
 //@ \subsection{Local variable access}
 

--- a/src/prep/core-preprocessing.k
+++ b/src/prep/core-preprocessing.k
@@ -12,12 +12,12 @@ module CORE-PREPROCESSING
     Uses <namesToClasses> to compute the result. Used by the starting rule of several preprocessing phases.
 */
 syntax KItem ::= "getTopLevelClasses"
-           | getTopLevelClasses ( Map, Set )
+               | getTopLevelClasses ( List, Set )
 
-rule [getTopLevelClasses-start]:
-    <k> getTopLevelClasses => getTopLevelClasses(NamesMap, .Set) ...</k>
-    <namesToClasses> NamesMap:Map </namesToClasses>
-//todo mapItem
+//rule [getTopLevelClasses-start]:
+//    <k> getTopLevelClasses => getTopLevelClasses(NamesMap, .Set) ...</k>
+//    <namesToClasses> NamesMap:Map </namesToClasses>
+//todo mapItem/solution
 //rule [getTopLevelClasses-top-level]:
 //    <k>
 //      getTopLevelClasses(_ _ |-> mapWrap(_ (_ |-> Class:ClassType => .Map)), _ (.Set => SetItem(Class)))
@@ -25,7 +25,7 @@ rule [getTopLevelClasses-start]:
 //    </k>
 //    <classType> Class </classType>
 //    <enclosingClass> noClass </enclosingClass>
-
+//
 //rule [getTopLevelClasses-not-top-level]:
 //    <k>
 //      getTopLevelClasses(_ _ |-> mapWrap(_ (_ |-> Class:ClassType => .Map)), _)
@@ -33,23 +33,53 @@ rule [getTopLevelClasses-start]:
 //    </k>
 //    <classType> Class </classType>
 //    <enclosingClass> class _ </enclosingClass>
-
+//
 //rule getTopLevelClasses(_ (_ |-> mapWrap(.Map) => .Map), _)
-rule getTopLevelClasses(.Map, ClassesSet:Set) => setWrap(ClassesSet)
+//rule getTopLevelClasses(.Map, ClassesSet:Set) => setWrap(ClassesSet)
+
+rule [getTopLevelClasses-start1]:
+    <k> getTopLevelClasses => getTopLevelClasses(values(NamesMap), .Set) ...</k>
+    <namesToClasses> NamesMap:Map </namesToClasses>
+
+rule [getTopLevelClasses-start2]:
+    <k> getTopLevelClasses((ListItem(mapWrap(M:Map)) => values(M)) _, _) ...</k>
+
+rule [getTopLevelClasses-top-level]:
+    <k>
+      getTopLevelClasses((ListItem(Class:ClassType) => .List) _, _ (.Set => SetItem(Class)))
+      ...
+    </k>
+    <classType> Class </classType>
+    <enclosingClass> noClass </enclosingClass>
+
+rule [getTopLevelClasses-not-top-level]:
+    <k>
+      getTopLevelClasses((ListItem(Class:ClassType) => .List) _, _)
+      ...
+    </k>
+    <classType> Class </classType>
+    <enclosingClass> class _ </enclosingClass>
+
+rule getTopLevelClasses(.List, ClassesSet:Set) => setWrap(ClassesSet)
+
 
 /*@ Returns a setWrap(Set[ClassType]), containing all direct inner classes of the given class.
     Uses <namesToClasses> to compute the result.
 */
 syntax KItem ::= getInnerClasses ( ClassType )
-           | getInnerClasses ( Map, Set )
-//todo mapItem
+               | getInnerClasses ( Map, Set )
+//todo mapItem/solution
 //rule [getInnerClasses-start-have-inner]:
 //    <k> getInnerClasses(Class:ClassType) => getInnerClasses(InnerClassesMap, .Set) ...</k>
 //    <namesToClasses>... Pack:PackageId |-> mapWrap(InnerClassesMap:Map) ...</namesToClasses>
 //when
 //    Pack ==K toPackage(Class)
 
-//rule getInnerClasses( (_ |-> Class:ClassType => .Map) _, (.Set => SetItem(Class)) _)
+rule [getInnerClasses-start-have-inner]:
+    <k> getInnerClasses(class Class:Id) => getInnerClasses(InnerClassesMap, .Set) ...</k>
+    <namesToClasses>... packageId(Class) |-> mapWrap(InnerClassesMap:Map) ...</namesToClasses>
+
+rule getInnerClasses( (_ |-> Class:ClassType => .Map) _, (.Set => SetItem(Class)) _)
 rule getInnerClasses(.Map, ClassesSet:Set) => setWrap(ClassesSet)
 
 rule [getInnerClasses-no-inners]:

--- a/src/prep/core-preprocessing.k
+++ b/src/prep/core-preprocessing.k
@@ -4,7 +4,7 @@
 
 module CORE-PREPROCESSING
     imports CORE-SORTS
-    imports CORE-FUNCTIONS
+    imports CORE-CLASSES
 
 //@ \subsection{Auxiliary constructs for retrieving a set of classes}
 

--- a/src/prep/core-preprocessing.k
+++ b/src/prep/core-preprocessing.k
@@ -17,24 +17,24 @@ syntax KItem ::= "getTopLevelClasses"
 rule [getTopLevelClasses-start]:
     <k> getTopLevelClasses => getTopLevelClasses(NamesMap, .Set) ...</k>
     <namesToClasses> NamesMap:Map </namesToClasses>
+//todo mapItem
+//rule [getTopLevelClasses-top-level]:
+//    <k>
+//      getTopLevelClasses(_ _ |-> mapWrap(_ (_ |-> Class:ClassType => .Map)), _ (.Set => SetItem(Class)))
+//      ...
+//    </k>
+//    <classType> Class </classType>
+//    <enclosingClass> noClass </enclosingClass>
 
-rule [getTopLevelClasses-top-level]:
-    <k>
-      getTopLevelClasses(_ _ |-> mapWrap(_ (_ |-> Class:ClassType => .Map)), _ (.Set => SetItem(Class)))
-      ...
-    </k>
-    <classType> Class </classType>
-    <enclosingClass> noClass </enclosingClass>
+//rule [getTopLevelClasses-not-top-level]:
+//    <k>
+//      getTopLevelClasses(_ _ |-> mapWrap(_ (_ |-> Class:ClassType => .Map)), _)
+//      ...
+//    </k>
+//    <classType> Class </classType>
+//    <enclosingClass> class _ </enclosingClass>
 
-rule [getTopLevelClasses-not-top-level]:
-    <k>
-      getTopLevelClasses(_ _ |-> mapWrap(_ (_ |-> Class:ClassType => .Map)), _)
-      ...
-    </k>
-    <classType> Class </classType>
-    <enclosingClass> class _ </enclosingClass>
-
-rule getTopLevelClasses(_ (_ |-> mapWrap(.Map) => .Map), _)
+//rule getTopLevelClasses(_ (_ |-> mapWrap(.Map) => .Map), _)
 rule getTopLevelClasses(.Map, ClassesSet:Set) => setWrap(ClassesSet)
 
 /*@ Returns a setWrap(Set[ClassType]), containing all direct inner classes of the given class.
@@ -42,14 +42,14 @@ rule getTopLevelClasses(.Map, ClassesSet:Set) => setWrap(ClassesSet)
 */
 syntax KItem ::= getInnerClasses ( ClassType )
            | getInnerClasses ( Map, Set )
+//todo mapItem
+//rule [getInnerClasses-start-have-inner]:
+//    <k> getInnerClasses(Class:ClassType) => getInnerClasses(InnerClassesMap, .Set) ...</k>
+//    <namesToClasses>... Pack:PackageId |-> mapWrap(InnerClassesMap:Map) ...</namesToClasses>
+//when
+//    Pack ==K toPackage(Class)
 
-rule [getInnerClasses-start-have-inner]:
-    <k> getInnerClasses(Class:ClassType) => getInnerClasses(InnerClassesMap, .Set) ...</k>
-    <namesToClasses>... Pack:PackageId |-> mapWrap(InnerClassesMap:Map) ...</namesToClasses>
-when
-    Pack ==K toPackage(Class)
-
-rule getInnerClasses( (_ |-> Class:ClassType => .Map) _, (.Set => SetItem(Class)) _)
+//rule getInnerClasses( (_ |-> Class:ClassType => .Map) _, (.Set => SetItem(Class)) _)
 rule getInnerClasses(.Map, ClassesSet:Set) => setWrap(ClassesSet)
 
 rule [getInnerClasses-no-inners]:

--- a/src/prep/elaboration-arrays.k
+++ b/src/prep/elaboration-arrays.k
@@ -3,6 +3,7 @@
 module ELABORATION-ARRAYS
     imports CORE-SORTS
     imports ELABORATION-CORE
+    imports ELABORATION-EXPRESSIONS//for elabExpAndType
 
 //@ \subsection{Desugaring of array declarators with c-style dimensions and initializers}
 

--- a/src/prep/elaboration-core.k
+++ b/src/prep/elaboration-core.k
@@ -57,7 +57,7 @@ module ELABORATION-CORE
     imports CORE-SORTS
     imports SUBTYPING
     imports ELABORATION-CATEGORIES
-    imports ELABORATION-EXPRESSIONS // for isExpressionLabel
+
 
 /*@Custom hole used for custom heating/cooling rules in the elaboration phase.*/
 syntax KItem ::= "CHOLE"

--- a/src/prep/elaboration-core.k
+++ b/src/prep/elaboration-core.k
@@ -109,14 +109,14 @@ context  elab('Param(_:K,, HOLE,, _:Id))
 */
 rule [elab-Param]:
     <k> elab('Param(K1:K,, T:Type,, X:Id)) => elabRes('Param(K1:K,, T:Type,, X:Id)) ...</k>
-    <elabEnv> ListItem(mapWrap((. => X |-> T) _)) ...</elabEnv>
+    <elabEnv> ListItem(mapWrap((.Map => X |-> T) _)) ...</elabEnv>
 
 //@Removes the last layer from <elabEnv>
 syntax KItem ::= "removeLastElabEnv"
 rule [removeLastElabEnv]:
-    <k> removeLastElabEnv => . ...</k>
-    <elabEnv> ListItem(_) => . ...</elabEnv>
-    <localTypes> ListItem(_) => . ...</localTypes>
+    <k> removeLastElabEnv => .K ...</k>
+    <elabEnv> ListItem(_) => .List ...</elabEnv>
+    <localTypes> ListItem(_) => .List ...</localTypes>
 
 /*@ \subsection{Elaboration of code blocks} */
 
@@ -182,7 +182,7 @@ when
 syntax KItem ::= haveElabRes ( KListWrap )          [function]
 rule haveElabRes([_,, elabRes(_),, _]) => true
 
-//K bug additional rule required since we introduced KListWrap? todo
+//K bug additional rule required since we introduced KListWrap? todo (Shijiao)
 //rule haveElabRes([_,, KList2KLabel _,, elabRes(_),, _ (_),, _]) => true
 
 /*@ The 3rd elaboration-phase wrapper for expressions. Represents the case when children are completely elaborated and

--- a/src/prep/elaboration-core.k
+++ b/src/prep/elaboration-core.k
@@ -182,8 +182,8 @@ when
 syntax KItem ::= haveElabRes ( KListWrap )          [function]
 rule haveElabRes([_,, elabRes(_),, _]) => true
 
-//K bug additional rule required since we introduced KListWrap
-rule haveElabRes([_,, KList2KLabel _,, elabRes(_),, _ (_),, _]) => true
+//K bug additional rule required since we introduced KListWrap? todo
+//rule haveElabRes([_,, KList2KLabel _,, elabRes(_),, _ (_),, _]) => true
 
 /*@ The 3rd elaboration-phase wrapper for expressions. Represents the case when children are completely elaborated and
 unwrapped from elabRes(), but root node might not be elaborated yet. The implementation is scattered across all modules

--- a/src/prep/elaboration-method-invoke.k
+++ b/src/prep/elaboration-method-invoke.k
@@ -52,7 +52,8 @@ rule [elabEnd-findQualifierForName]:
     <methods> Methods:Map </methods>
 
 syntax KItem ::= containsName ( Map , Id )        [function]
-rule containsName((sig(Name, _) |-> _) _:Map, Name:Id) => true
+//todo mapItem
+//rule containsName((sig(Name, _) |-> _) _:Map, Name:Id) => true
 
 //@Happens for 'NewInstance expressions for static inner classes.
 rule [elabEnd-findQualifierForName-static]:
@@ -261,7 +262,7 @@ rule [lookupSignature-Main]:
       lookupSignature(
         MethodName:Id,
         CallTs:Types,
-        (sig(MethodName, SigTs:Types) |-> NewDecClass:ClassType => .) _:Map,
+        (sig(MethodName, SigTs:Types) |-> NewDecClass:ClassType => .Map) _:Map,
         IsQ:Bool,
         OldMethodRef:MethodRef
         => ifAux(
@@ -292,16 +293,16 @@ rule [lookupSignature-Main]:
 
 syntax KItem ::= getMethodRefArgTypes ( MethodRef )   [function]
 rule getMethodRefArgTypes( methodRef(sig(_, Ts:Types), _) ) => Ts
-
-rule [lookupSignature-SigDiscard]:
-    lookupSignature(
-      MethodName:Id,
-      _,
-      (sig(Name:Id, _) |-> _ => .) _:Map,
-      _,_,_
-    )
-when
-    Name =/=K MethodName
+//todo mapItem
+//rule [lookupSignature-SigDiscard]:
+//    lookupSignature(
+//      MethodName:Id,
+//      _,
+//      (sig(Name:Id, _) |-> _ => .) _:Map,
+//      _,_,_
+//    )
+//when
+//    Name =/=K MethodName
 
 rule [lookupSignature-End]:
     lookupSignature(_,_, .Map,_, MethodRef:MethodRef, _) => MethodRef

--- a/src/prep/elaboration-method-invoke.k
+++ b/src/prep/elaboration-method-invoke.k
@@ -51,9 +51,15 @@ rule [elabEnd-findQualifierForName]:
     <enclosingClass> QualEncloserClass:ClassType </enclosingClass>
     <methods> Methods:Map </methods>
 
-syntax KItem ::= containsName ( Map , Id )        [function]
-//todo mapItem
-//rule containsName((sig(Name, _) |-> _) _:Map, Name:Id) => true
+//@Checks whether a given map contains the given Id in its key:sig(Id,_)
+syntax KItem ::= containsName ( Map , Id )                      [function]
+               | containsName ( Signature, Map , Id )           [function]
+
+//todo mapItem/solution
+rule containsName((S:Signature |-> _) Remains:Map, Name:Id) => containsName(S, Remains, Name)
+rule containsName(sig(Name,_), _, Name:Id) => true
+rule containsName(sig(Name1:Id,_), Remains:Map, Name:Id) => containsName(Remains, Name) when Name1 =/=K Name
+rule containsName(.Map, _) => false
 
 //@Happens for 'NewInstance expressions for static inner classes.
 rule [elabEnd-findQualifierForName-static]:

--- a/src/prep/elaboration-method-invoke.k
+++ b/src/prep/elaboration-method-invoke.k
@@ -299,16 +299,14 @@ rule [lookupSignature-Main]:
 
 syntax KItem ::= getMethodRefArgTypes ( MethodRef )   [function]
 rule getMethodRefArgTypes( methodRef(sig(_, Ts:Types), _) ) => Ts
-//todo mapItem
-//rule [lookupSignature-SigDiscard]:
-//    lookupSignature(
-//      MethodName:Id,
-//      _,
-//      (sig(Name:Id, _) |-> _ => .) _:Map,
-//      _,_,_
-//    )
-//when
-//    Name =/=K MethodName
+//todo mapItem/solution
+rule [lookupSignature-SigDiscard]:
+    lookupSignature(
+      MethodName:Id,
+      _,
+      (M:Map => mapItemsByPartialKey(M,MethodName)),
+      _,_,_
+    )
 
 rule [lookupSignature-End]:
     lookupSignature(_,_, .Map,_, MethodRef:MethodRef, _) => MethodRef

--- a/src/prep/elaboration-statements.k
+++ b/src/prep/elaboration-statements.k
@@ -24,8 +24,8 @@ This is because these statements are blocks that might declare local variables.
 */
 rule [elab-Block-For-Catch-heat-FirstSubterm]:
     <k> elab(KL:KLabel(K:K,, Ks:KList)) => elab(K) ~> elab(KL(CHOLE,, Ks:KList)) ...</k>
-    <elabEnv> (. => ListItem(ElabEnvLI)) ListItem(ElabEnvLI:K) ...</elabEnv>
-    <localTypes> (. => ListItem(LocalTypesLI)) ListItem(LocalTypesLI:K) ...</localTypes>
+    <elabEnv> (.List => ListItem(ElabEnvLI)) ListItem(ElabEnvLI:K) ...</elabEnv>
+    <localTypes> (.List => ListItem(LocalTypesLI)) ListItem(LocalTypesLI:K) ...</localTypes>
 when
     isVarDecHolderLabel(KL) ==K true andBool notBool isElabKResult(K) ==K true
 
@@ -72,7 +72,7 @@ rule [elab-LocalVarDec]:
       => elabRes('LocalVarDec(K,, T,, ['VarDec(X)]))
       ...
     </k>
-    <elabEnv> ListItem(mapWrap((. => X |-> T) _)) ...</elabEnv>
+    <elabEnv> ListItem(mapWrap((.Map => X |-> T) _)) ...</elabEnv>
 
 //@\subsection{Elaboration of SuperConstrInv, QSuperConstrInv, AltConstrInv}
 

--- a/src/prep/elaboration-statements.k
+++ b/src/prep/elaboration-statements.k
@@ -24,8 +24,8 @@ This is because these statements are blocks that might declare local variables.
 */
 rule [elab-Block-For-Catch-heat-FirstSubterm]:
     <k> elab(KL:KLabel(K:K,, Ks:KList)) => elab(K) ~> elab(KL(CHOLE,, Ks:KList)) ...</k>
-    <elabEnv> (. => ElabEnvLI) ElabEnvLI:ListItem ...</elabEnv>
-    <localTypes> (. => LocalTypesLI) LocalTypesLI:ListItem ...</localTypes>
+    <elabEnv> (. => ListItem(ElabEnvLI)) ListItem(ElabEnvLI:K) ...</elabEnv>
+    <localTypes> (. => ListItem(LocalTypesLI)) ListItem(LocalTypesLI:K) ...</localTypes>
 when
     isVarDecHolderLabel(KL) ==K true andBool notBool isElabKResult(K) ==K true
 

--- a/src/prep/elaboration-top-blocks.k
+++ b/src/prep/elaboration-top-blocks.k
@@ -102,12 +102,10 @@ rule [elabMethods-Cool-Constructor]:
     (<methodConstrFirstLine> FirstLine:K </methodConstrFirstLine> => .Bag)
     <methodBody> CHOLE => [FirstLine,, Body] </methodBody>
     <methodMetaType> constructorMMT => methodMMT </methodMetaType>
-//todo mapItemByValue
-//rule [elabMethods-discard-method]:
-//    <k> elabMethods( (Sig:Signature |-> DeclClass:ClassType => .Map) _) ... </k>
-//    <crntClass> Class:ClassType </crntClass>
-//when
-//    DeclClass =/=K Class
+//todo mapItemByValue/solution
+rule [elabMethods-discard-method]:
+    <k> elabMethods(M:Map => M -Map removeMapItemsByValue(M,Class) ) ... </k>
+    <crntClass> Class:ClassType </crntClass>
 
 rule [elabMethods-End]:
     elabMethods( .Map ) => .

--- a/src/prep/elaboration-top-blocks.k
+++ b/src/prep/elaboration-top-blocks.k
@@ -22,11 +22,11 @@ syntax KItem ::= elaborateBlocks ( K ) [strict]
 */
 rule [elaborateBlocks]:
     <k>
-      (. => elabMethods(Methods) ~> elabStaticInit
+      (.K => elabMethods(Methods) ~> elabStaticInit
         ~> elaborateBlocks(getInnerClasses(Class))
         ~> restoreCrntClass(OldCrntClass)
       )
-      ~> elaborateBlocks(setWrap((SetItem(Class:ClassType) => .) _:Set))
+      ~> elaborateBlocks(setWrap((SetItem(Class:ClassType) => .Set) _:Set))
       ...
     </k>
     <crntClass> OldCrntClass:ClassType => Class </crntClass>
@@ -102,12 +102,12 @@ rule [elabMethods-Cool-Constructor]:
     (<methodConstrFirstLine> FirstLine:K </methodConstrFirstLine> => .Bag)
     <methodBody> CHOLE => [FirstLine,, Body] </methodBody>
     <methodMetaType> constructorMMT => methodMMT </methodMetaType>
-
-rule [elabMethods-discard-method]:
-    <k> elabMethods( (Sig:Signature |-> DeclClass:ClassType => .Map) _) ... </k>
-    <crntClass> Class:ClassType </crntClass>
-when
-    DeclClass =/=K Class
+//todo mapItemByValue
+//rule [elabMethods-discard-method]:
+//    <k> elabMethods( (Sig:Signature |-> DeclClass:ClassType => .Map) _) ... </k>
+//    <crntClass> Class:ClassType </crntClass>
+//when
+//    DeclClass =/=K Class
 
 rule [elabMethods-End]:
     elabMethods( .Map ) => .
@@ -131,8 +131,8 @@ rule [elabStaticInit-End]:
 //@Adds a new empty layer to <elabEnv>
 syntax KItem ::= "addElabEnv"
 rule [addElabEnv]:
-    <k> addElabEnv => . ...</k>
-    <elabEnv> . => ListItem(mapWrap(.Map)) ...</elabEnv>
-    <localTypes> . => ListItem(mapWrap(.Map)) ...</localTypes>
+    <k> addElabEnv => .K ...</k>
+    <elabEnv> .List => ListItem(mapWrap(.Map)) ...</elabEnv>
+    <localTypes> .List => ListItem(mapWrap(.Map)) ...</localTypes>
 
 endmodule

--- a/src/prep/elaboration-types.k
+++ b/src/prep/elaboration-types.k
@@ -33,7 +33,7 @@ rule [TypeName-QualifiedPackage]:
 syntax KItem ::= typeNameQualifiedImpl ( K, Id ) [strict(1)]
 
 rule [typeNameQualifiedImpl-Found]:
-    typeNameQualifiedImpl(mapWrap(X |-> Class:ClassType _), X:Id) => Class
+    typeNameQualifiedImpl(mapWrap((X |-> Class:ClassType) _), X:Id) => Class
 
 rule [typeNameQualifiedImpl-NotFound]:
     typeNameQualifiedImpl(mapWrap(NamesMap:Map), X:Id) => noValue
@@ -41,7 +41,7 @@ when notBool X in keys(NamesMap)
 
 rule [TypeName-local-in-any-Phase]:
     <k> 'TypeName(X:Id) => Class ...</k>
-    <localTypes> ListItem(mapWrap(X |-> Class:ClassType _)) ...</localTypes>
+    <localTypes> ListItem(mapWrap((X |-> Class:ClassType) _)) ...</localTypes>
 
 rule [TypeName-global]:
     <k> 'TypeName(X:Id) => Class ...</k>

--- a/src/prep/elaboration-vars.k
+++ b/src/prep/elaboration-vars.k
@@ -9,7 +9,7 @@ rule [elabEnd-AmbName]:
 
 rule [elabEnd-ExprName-localVar-ok]:
     <k> elabEnd('ExprName(X:Id)) => elabRes(cast(T, 'ExprName(X))) ...</k>
-    <elabEnv> ListItem(mapWrap(X |-> T:Type _)) ...</elabEnv>
+    <elabEnv> ListItem(mapWrap((X |-> T:Type) _)) ...</elabEnv>
 
 rule [elabEnd-localVar-to-noValue]:
     <k> elabEnd('ExprName(X:Id)) => externalVar(X, Class) ...</k>

--- a/src/prep/folding.k
+++ b/src/prep/folding.k
@@ -101,53 +101,49 @@ rule [folding-class-end]:
     ( <methodDecs> .Bag </methodDecs> => .Bag)
     <folded> _:KLabel(_) </folded>
     <classPhase> MembersProcessedCPhase => FoldedCPhase </classPhase>
+//todo mapItem/solution
+rule [folding-class-fold-top-level]:
+    <k> foldingPhase </k>
+    <namesToClasses>
+      packageId(Class) |-> mapWrap(.Map)
+      ...
+    </namesToClasses>
+    ( <class>
+        <classType> class Class:Id </classType>
+        <enclosingClass> noClass </enclosingClass>
+        <folded> ClassDec:K </folded>
+        <classPhase> FoldedCPhase </classPhase>
+        ...
+      </class> => .Bag
+    )
+    <program> [_,, (.KList => ClassDec)] </program>
 //todo mapItem
-//rule [folding-class-fold-top-level]:
-//    <k> foldingPhase </k>
-//    <namesToClasses>
-//      ClassPack:PackageId |-> mapWrap(.Map)
-//      ...
-//    </namesToClasses>
-//    ( <class>
-//        <classType> Class:ClassType </classType>
-//        <enclosingClass> noClass </enclosingClass>
-//        <folded> ClassDec:K </folded>
-//        <classPhase> FoldedCPhase </classPhase>
-//        ...
-//      </class> => .Bag
-//    )
-//    <program> [_,, (.KList => ClassDec)] </program>
-//when
-//    ClassPack ==K toPackage(Class)
-
-//rule [folding-class-fold-inner]:
-//    <k> foldingPhase </k>
-//    <namesToClasses>
-//      ClassPack:PackageId |-> mapWrap(.Map)
-//      EnclosingClassPack:PackageId |-> mapWrap(_:Map (_ |-> Class => .Map) )
-//      ...
-//    </namesToClasses>
-//    ( <class>
-//        <classType> Class:ClassType </classType>
-//        <enclosingClass> EnclosingClass:ClassType </enclosingClass>
-//        <folded> ClassDec:K </folded>
-//        <classPhase> FoldedCPhase </classPhase>
-//        ...
-//      </class> => .Bag
-//    )
-//    <class>
-//      <classType> EnclosingClass </classType>
-//      <folded>
-//        _:KLabel(
-//          'ClassDecHead(_),,
-//          'ClassBody( [_,, ( .KList => ClassDec )] )
-//        )
-//      </folded>
-//      <classPhase> FoldedCPhase </classPhase>
-//      ...
-//    </class>
-//when
-//    ClassPack ==K toPackage(Class) andBool EnclosingClassPack ==K toPackage(EnclosingClass)
+rule [folding-class-fold-inner]:
+    <k> foldingPhase </k>
+    <namesToClasses>
+      packageId(Class) |-> mapWrap(.Map)
+//      packageId(EnclosingClass) |-> mapWrap(_:Map (_ |-> class Class => .Map) )
+      ...
+    </namesToClasses>
+    ( <class>
+        <classType> class Class:Id </classType>
+        <enclosingClass> class EnclosingClass:Id </enclosingClass>
+        <folded> ClassDec:K </folded>
+        <classPhase> FoldedCPhase </classPhase>
+        ...
+      </class> => .Bag
+    )
+    <class>
+      <classType> class EnclosingClass </classType>
+      <folded>
+        _:KLabel(
+          'ClassDecHead(_),,
+          'ClassBody( [_,, ( .KList => ClassDec )] )
+        )
+      </folded>
+      <classPhase> FoldedCPhase </classPhase>
+      ...
+    </class>
 
 rule [FoldingPhase-end]:
     <k> foldingPhase => . </k>

--- a/src/prep/folding.k
+++ b/src/prep/folding.k
@@ -101,53 +101,53 @@ rule [folding-class-end]:
     ( <methodDecs> .Bag </methodDecs> => .Bag)
     <folded> _:KLabel(_) </folded>
     <classPhase> MembersProcessedCPhase => FoldedCPhase </classPhase>
+//todo mapItem
+//rule [folding-class-fold-top-level]:
+//    <k> foldingPhase </k>
+//    <namesToClasses>
+//      ClassPack:PackageId |-> mapWrap(.Map)
+//      ...
+//    </namesToClasses>
+//    ( <class>
+//        <classType> Class:ClassType </classType>
+//        <enclosingClass> noClass </enclosingClass>
+//        <folded> ClassDec:K </folded>
+//        <classPhase> FoldedCPhase </classPhase>
+//        ...
+//      </class> => .Bag
+//    )
+//    <program> [_,, (.KList => ClassDec)] </program>
+//when
+//    ClassPack ==K toPackage(Class)
 
-rule [folding-class-fold-top-level]:
-    <k> foldingPhase </k>
-    <namesToClasses>
-      ClassPack:PackageId |-> mapWrap(.Map)
-      ...
-    </namesToClasses>
-    ( <class>
-        <classType> Class:ClassType </classType>
-        <enclosingClass> noClass </enclosingClass>
-        <folded> ClassDec:K </folded>
-        <classPhase> FoldedCPhase </classPhase>
-        ...
-      </class> => .Bag
-    )
-    <program> [_,, (.KList => ClassDec)] </program>
-when
-    ClassPack ==K toPackage(Class)
-
-rule [folding-class-fold-inner]:
-    <k> foldingPhase </k>
-    <namesToClasses>
-      ClassPack:PackageId |-> mapWrap(.Map)
-      EnclosingClassPack:PackageId |-> mapWrap(_:Map (_ |-> Class => .Map) )
-      ...
-    </namesToClasses>
-    ( <class>
-        <classType> Class:ClassType </classType>
-        <enclosingClass> EnclosingClass:ClassType </enclosingClass>
-        <folded> ClassDec:K </folded>
-        <classPhase> FoldedCPhase </classPhase>
-        ...
-      </class> => .Bag
-    )
-    <class>
-      <classType> EnclosingClass </classType>
-      <folded>
-        _:KLabel(
-          'ClassDecHead(_),,
-          'ClassBody( [_,, ( .KList => ClassDec )] )
-        )
-      </folded>
-      <classPhase> FoldedCPhase </classPhase>
-      ...
-    </class>
-when
-    ClassPack ==K toPackage(Class) andBool EnclosingClassPack ==K toPackage(EnclosingClass)
+//rule [folding-class-fold-inner]:
+//    <k> foldingPhase </k>
+//    <namesToClasses>
+//      ClassPack:PackageId |-> mapWrap(.Map)
+//      EnclosingClassPack:PackageId |-> mapWrap(_:Map (_ |-> Class => .Map) )
+//      ...
+//    </namesToClasses>
+//    ( <class>
+//        <classType> Class:ClassType </classType>
+//        <enclosingClass> EnclosingClass:ClassType </enclosingClass>
+//        <folded> ClassDec:K </folded>
+//        <classPhase> FoldedCPhase </classPhase>
+//        ...
+//      </class> => .Bag
+//    )
+//    <class>
+//      <classType> EnclosingClass </classType>
+//      <folded>
+//        _:KLabel(
+//          'ClassDecHead(_),,
+//          'ClassBody( [_,, ( .KList => ClassDec )] )
+//        )
+//      </folded>
+//      <classPhase> FoldedCPhase </classPhase>
+//      ...
+//    </class>
+//when
+//    ClassPack ==K toPackage(Class) andBool EnclosingClassPack ==K toPackage(EnclosingClass)
 
 rule [FoldingPhase-end]:
     <k> foldingPhase => . </k>

--- a/src/prep/folding.k
+++ b/src/prep/folding.k
@@ -117,12 +117,12 @@ rule [folding-class-fold-top-level]:
       </class> => .Bag
     )
     <program> [_,, (.KList => ClassDec)] </program>
-//todo mapItem
+//todo mapItem/solution
 rule [folding-class-fold-inner]:
     <k> foldingPhase </k>
     <namesToClasses>
       packageId(Class) |-> mapWrap(.Map)
-//      packageId(EnclosingClass) |-> mapWrap(_:Map (_ |-> class Class => .Map) )
+      packageId(EnclosingClass) |-> mapWrap(M:Map => removeMapItemsByValue(M, class Class))
       ...
     </namesToClasses>
     ( <class>

--- a/src/prep/process-class-members.k
+++ b/src/prep/process-class-members.k
@@ -10,7 +10,7 @@ module PROCESS-CLASS-MEMBERS
 /*@ We need to process Object first. Thus when we will process any interfaces,
     Object class will already be processed.*/
 rule [Start-ProcClassMembersPhase]:
-    <k> . => processTypeWithDepends(classObject) ~> processClasses(getTopLevelClasses) </k>
+    <k> .K => processTypeWithDepends(classObject) ~> processClasses(getTopLevelClasses) </k>
     <globalPhase> ProcClassDecsPhase => ProcClassMembersPhase  </globalPhase>
 
 syntax KItem ::=  processClasses (
@@ -20,10 +20,10 @@ syntax KItem ::=  processClasses (
 
 rule [processClasses]:
     (. => processTypeWithDepends(Class))
-    ~>  processClasses(setWrap( (SetItem(Class:ClassType) => .) _:Set))
+    ~>  processClasses(setWrap( (SetItem(Class:ClassType) => .Set) _:Set))
 
 rule [processClasses-Discard]:
-    processClasses(setWrap(.)) => .
+    processClasses(setWrap(.Set)) => .K
 
 syntax KItem ::=  processTypeWithDepends (
                 ClassType  //the class to be processed,
@@ -43,7 +43,7 @@ rule [processTypeWithDepends]:
     <classPhase> DecsProcessedCPhase </classPhase>
 
 rule [processTypeWithDepends-Discard]:
-    <k> processTypeWithDepends(Class:ClassType) => . ...</k>
+    <k> processTypeWithDepends(Class:ClassType) => .K ...</k>
     <classType> Class </classType>
     <classPhase> MembersProcessedCPhase </classPhase>
 
@@ -91,7 +91,7 @@ rule [processType]:
       <classType> Class </classType>
       <extends> BaseClass:ClassType </extends>
       <implements> ISet:Set </implements>
-      <implTrans> . => ISet </implTrans>
+      <implTrans> .Set => ISet </implTrans>
       ( <rawDeclarations> Decls:K </rawDeclarations> => .Bag)
       <classMetaType> MetaT:ClassMetaType </classMetaType>
       <classPhase> DecsProcessedCPhase => MembersProcessedCPhase </classPhase>
@@ -100,7 +100,7 @@ rule [processType]:
 
 //Could happen when hierarchies of inheritance and that of enclosing get messed up.
 rule [processType-discard]:
-    <k> processType(Class:ClassType) => . ...</k>
+    <k> processType(Class:ClassType) => .K ...</k>
     <classType> Class </classType>
     <classPhase> MembersProcessedCPhase </classPhase>
 
@@ -110,7 +110,7 @@ syntax KItem ::= computeImplTrans ( Set )
 rule [computeImplTrans]:
     <k>
       (. => saveImplTrans(setUnion(setWrap(ITrans), setWrap(BaseItfITrans))))
-      ~> computeImplTrans( (SetItem(BaseItf:ClassType) => .) _)
+      ~> computeImplTrans( (SetItem(BaseItf:ClassType) => .Set) _)
       ...
     </k>
     <crntClass> Class:ClassType </crntClass>
@@ -119,16 +119,16 @@ rule [computeImplTrans]:
     <classType> BaseItf </classType>
     <implTrans> BaseItfITrans:Set </implTrans>
 
-rule [computeImplTrans-Elem-Discard]: computeImplTrans( (SetItem(noClass) => .) _)
+rule [computeImplTrans-Elem-Discard]: computeImplTrans( (SetItem(noClass) => .Set) _)
 
-rule [computeImplTrans-Discard]: computeImplTrans(.) => .
+rule [computeImplTrans-Discard]: computeImplTrans(.Set) => .K
 
 syntax KItem ::=  saveImplTrans (
                 K //setWrap(ISet) - transitive set of inherited interfaces
               )
               [strict]
 
-rule <k> saveImplTrans(setWrap(S1:Set)) => . ...</k>
+rule <k> saveImplTrans(setWrap(S1:Set)) => .K ...</k>
      <crntClass> Class:ClassType </crntClass>
      <classType> Class </classType>
      <implTrans> _ => S1 </implTrans>
@@ -139,9 +139,9 @@ syntax KItem ::= tryInheritSet ( Set )
            | tryInheritImpl ( Map )
 
 rule [tryInheritSet]:
-    (. => tryInherit(Class:ClassType)) ~> tryInheritSet( (SetItem(Class) => .) _)
+    (.K => tryInherit(Class:ClassType)) ~> tryInheritSet( (SetItem(Class) => .Set) _)
 
-rule [tryInheritSet-Discard]: tryInheritSet(.) => .
+rule [tryInheritSet-Discard]: tryInheritSet(.Set) => .K
 
 rule [tryInherit]:
     <k>
@@ -154,8 +154,9 @@ rule [tryInherit]:
 rule [tryInherit-Discard]:
     tryInherit(noClass) => .K
 
-rule [tryInheritImpl-Unfold]:
-    <k> (. => tryInheritImpl((M |-> I))) ~> tryInheritImpl( ((M:K |-> I:K) => .) _|->_ _) ...</k>
+//todo mapItem
+//rule [tryInheritImpl-Unfold]:
+//    <k> (.K => tryInheritImpl((M |-> I))) ~> tryInheritImpl( ((M:K |-> I:K) => .Map) _|->_ _) ...</k>
 
 rule [tryInheritImpl]:
     tryInheritImpl(Sig:K |-> DecClass:ClassType)
@@ -165,7 +166,7 @@ rule [tryInheritImpl]:
           .K
        )
 
-rule [tryInheritImpl-empty-Discard]: tryInheritImpl(.Map) => .
+rule [tryInheritImpl-empty-Discard]: tryInheritImpl(.Map) => .K
 
 syntax KItem ::= isInheritable ( AccessMode )                        [strict]
 

--- a/src/prep/process-class-members.k
+++ b/src/prep/process-class-members.k
@@ -155,7 +155,7 @@ rule [tryInherit-Discard]:
     tryInherit(noClass) => .K
 
 rule [tryInheritImpl-Unfold]:
-    <k> (. => tryInheritImpl(MI)) ~> tryInheritImpl( (MI:MapItem => .) _:MapItem _) ...</k>
+    <k> (. => tryInheritImpl((M |-> I))) ~> tryInheritImpl( ((M:K |-> I:K) => .) _|->_ _) ...</k>
 
 rule [tryInheritImpl]:
     tryInheritImpl(Sig:K |-> DecClass:ClassType)

--- a/src/prep/process-class-members.k
+++ b/src/prep/process-class-members.k
@@ -204,7 +204,7 @@ rule [inherit]:
     <k> inherit(methodRef(Sig:Signature, DecClass:ClassType)) => . ...</k>
     <crntClass> Class:ClassType </crntClass>
     <classType> Class </classType>
-    <methods> Env:Map => Env[DecClass/Sig] </methods>
+    <methods> Env:Map => Env[Sig <- DecClass] </methods>
 
 /*@ \subsection{Method declaration}
 Methods are now typed and we need to store their types in their
@@ -294,7 +294,7 @@ rule [storeMethod]:
     </k>
     <crntClass> Class:ClassType </crntClass>
     <classType> Class </classType>
-    <methods> Env:Map => Env[Class / Sig] </methods>
+    <methods> Env:Map => Env[Sig <- Class] </methods>
     ( .Bag => <methodDec>
                      <methodSignature> Sig </methodSignature>
                      <methodReturnType> ReturnType </methodReturnType>
@@ -477,7 +477,7 @@ rule [FieldDec-compile-time-constant]:
     </k>
     <crntClass> Class:ClassType </crntClass>
     <classType> Class </classType>
-    <constantEnv> Env:Map => Env[TV/X] </constantEnv>
+    <constantEnv> Env:Map => Env[X <- TV] </constantEnv>
 when
             getContextType(Modifiers) ==K staticCT
     andBool isFinalModifiers(Modifiers)

--- a/src/prep/process-class-members.k
+++ b/src/prep/process-class-members.k
@@ -137,6 +137,7 @@ rule <k> saveImplTrans(setWrap(S1:Set)) => .K ...</k>
 syntax KItem ::= tryInheritSet ( Set )
            | tryInherit ( ClassType )
            | tryInheritImpl ( Map )
+           | tryInheritImpl ( K , K )
 
 rule [tryInheritSet]:
     (.K => tryInherit(Class:ClassType)) ~> tryInheritSet( (SetItem(Class) => .Set) _)
@@ -154,12 +155,12 @@ rule [tryInherit]:
 rule [tryInherit-Discard]:
     tryInherit(noClass) => .K
 
-//todo mapItem
-//rule [tryInheritImpl-Unfold]:
-//    <k> (.K => tryInheritImpl((M |-> I))) ~> tryInheritImpl( ((M:K |-> I:K) => .Map) _|->_ _) ...</k>
+//todo mapItem/solution
+rule [tryInheritImpl-Unfold]:
+    (.K => tryInheritImpl(M, I)) ~> tryInheritImpl((M:K |-> I:K => .Map) _:Map)
 
 rule [tryInheritImpl]:
-    tryInheritImpl(Sig:K |-> DecClass:ClassType)
+    tryInheritImpl(Sig:K , DecClass:ClassType)
     => ifAux(
           isInheritable(getMethodAccessMode(methodRef(Sig, DecClass))),
           inherit(methodRef(Sig, DecClass)),

--- a/src/prep/process-imports.k
+++ b/src/prep/process-imports.k
@@ -40,7 +40,12 @@ rule [TypeImportOnDemandDec]:
 syntax KItem ::=  importOnDemandImpl (
                 Map //Map[X |-> Class] - classes to consider for importing.
               )
-//todo mapItemByValue
+//flattens the first mapItem as a walkaround to match mapItem by Value
+syntax KItem ::= importOnDemandImpl (Id,ClassType,Map)
+
+rule [importOnDemandImplConversion]:
+    importOnDemandImpl((Key:Id |-> Value:ClassType) Remains:Map) => importOnDemandImpl(Key,Value,Remains)
+//todo mapItemByValue/ is this solution ok?
 //rule [importOnDemandImpl-public]:
 //    <k> importOnDemandImpl((X:Id |-> Class:ClassType => .Map) _:Map) ...</k>
 //    <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
@@ -51,6 +56,17 @@ syntax KItem ::=  importOnDemandImpl (
 //    <k> importOnDemandImpl((X:Id |-> Class:ClassType => .Map) _:Map) ...</k>
 //    <classType> Class </classType>
 //    <classAccessMode> package </classAccessMode>
+
+rule [importOnDemandImpl-public]:
+    <k> (importOnDemandImpl(X:Id, Class:ClassType, Remains:Map) => importOnDemandImpl(Remains)) ...</k>
+    <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
+    <classType> Class </classType>
+    <classAccessMode> public </classAccessMode>
+
+rule [importOnDemandImpl-package]:
+    <k> (importOnDemandImpl(X:Id, Class:ClassType, Remains:Map) => importOnDemandImpl(Remains)) ...</k>
+    <classType> Class </classType>
+    <classAccessMode> package </classAccessMode>
 
 rule [importOnDemandImpl-discard]:
     importOnDemandImpl(.Map) => .K

--- a/src/prep/process-imports.k
+++ b/src/prep/process-imports.k
@@ -20,11 +20,11 @@ rule [compUnitImportsStart]:
 
 //Process K-AST terms 'TypeImportDec or 'TypeImportOnDemandDec
 context 'TypeImportDec(HOLE)
-
-rule [TypeImportDec]:
-    <k> 'TypeImportDec(Class:ClassType) => . ...</k>
-    <namesToClasses>... _ |-> mapWrap((X:Id |-> Class) _) ...</namesToClasses>
-    <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
+//todo mapItemByValue
+//rule [TypeImportDec]:
+//    <k> 'TypeImportDec(Class:ClassType) => . ...</k>
+//    <namesToClasses>... _ |-> mapWrap((X:Id |-> Class) _) ...</namesToClasses>
+//    <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
 
 context 'TypeImportOnDemandDec(HOLE)
 
@@ -42,9 +42,8 @@ syntax KItem ::=  importOnDemandImpl (
               )
 
 rule [importOnDemandImpl-public]:
-    <k> importOnDemandImpl((X:Id |-> Class:ClassType => .) _) ...</k>
+    <k> importOnDemandImpl((X:Id |-> Class:ClassType => .Map) _:Map) ...</k>
     <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
-    //<compUnitImports> (Imp:Map => update(Imp, X |-> Class)) </compUnitImports>
     <classType> Class </classType>
     <classAccessMode> public </classAccessMode>
 

--- a/src/prep/process-imports.k
+++ b/src/prep/process-imports.k
@@ -40,17 +40,17 @@ rule [TypeImportOnDemandDec]:
 syntax KItem ::=  importOnDemandImpl (
                 Map //Map[X |-> Class] - classes to consider for importing.
               )
+//todo mapItemByValue
+//rule [importOnDemandImpl-public]:
+//    <k> importOnDemandImpl((X:Id |-> Class:ClassType => .Map) _:Map) ...</k>
+//    <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
+//    <classType> Class </classType>
+//    <classAccessMode> public </classAccessMode>
 
-rule [importOnDemandImpl-public]:
-    <k> importOnDemandImpl((X:Id |-> Class:ClassType => .Map) _:Map) ...</k>
-    <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
-    <classType> Class </classType>
-    <classAccessMode> public </classAccessMode>
-
-rule [importOnDemandImpl-package]:
-    <k> importOnDemandImpl((X:Id |-> Class:ClassType => .) _) ...</k>
-    <classType> Class </classType>
-    <classAccessMode> package </classAccessMode>
+//rule [importOnDemandImpl-package]:
+//    <k> importOnDemandImpl((X:Id |-> Class:ClassType => .Map) _:Map) ...</k>
+//    <classType> Class </classType>
+//    <classAccessMode> package </classAccessMode>
 
 rule [importOnDemandImpl-discard]:
     importOnDemandImpl(.Map) => .K
@@ -60,7 +60,7 @@ This is required because some tests import some packages from JDK that are not i
 class-lib.*/
 rule [TypeImportOnDemandDec-Unexisting]:
     <k>
-      'TypeImportOnDemandDec(Pack:PackageId) => .
+      'TypeImportOnDemandDec(Pack:PackageId) => .K
       ...
     </k>
     <namesToClasses> PackMap:Map </namesToClasses>

--- a/src/prep/process-imports.k
+++ b/src/prep/process-imports.k
@@ -25,6 +25,24 @@ context 'TypeImportDec(HOLE)
 //    <k> 'TypeImportDec(Class:ClassType) => . ...</k>
 //    <namesToClasses>... _ |-> mapWrap((X:Id |-> Class) _) ...</namesToClasses>
 //    <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
+syntax KItem ::= typeImportDecImpl (List, ClassType)
+
+rule [typeImportDecImplConversion]:
+     typeImportDecImpl((ListItem(mapWrap((Key:Id |-> Value:K) Remains:Map)) =>
+                        ListItem(Key) ListItem(Value) ListItem(mapWrap(Remains))) _:List, _)
+
+rule typeImportDecImpl((ListItem(Key:Id) ListItem(Value:K) => .List) _:List, Class:ClassType)
+when Class =/=K Value
+
+rule <k> typeImportDecImpl((ListItem(X:Id) ListItem(Class) => .List) _:List, Class:ClassType)  ...</k>
+     <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
+
+rule typeImportDecImpl((ListItem(mapWrap(.Map)) => .List) _:List,_)
+rule typeImportDecImpl(.List,_) => .K
+
+rule [TypeImportDec]:
+    <k> 'TypeImportDec(Class:ClassType) => typeImportDecImpl(values(M), Class) ...</k>
+    <namesToClasses> M:Map </namesToClasses>
 
 context 'TypeImportOnDemandDec(HOLE)
 

--- a/src/prep/process-imports.k
+++ b/src/prep/process-imports.k
@@ -23,8 +23,8 @@ context 'TypeImportDec(HOLE)
 
 rule [TypeImportDec]:
     <k> 'TypeImportDec(Class:ClassType) => . ...</k>
-    <namesToClasses>... _ |-> mapWrap(X:Id |-> Class _) ...</namesToClasses>
-    <compUnitImports> Imp:Map => Imp[Class / X] </compUnitImports>
+    <namesToClasses>... _ |-> mapWrap((X:Id |-> Class) _) ...</namesToClasses>
+    <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
 
 context 'TypeImportOnDemandDec(HOLE)
 
@@ -43,7 +43,7 @@ syntax KItem ::=  importOnDemandImpl (
 
 rule [importOnDemandImpl-public]:
     <k> importOnDemandImpl((X:Id |-> Class:ClassType => .) _) ...</k>
-    <compUnitImports> Imp:Map => Imp[Class / X] </compUnitImports>
+    <compUnitImports> Imp:Map => Imp[X <- Class] </compUnitImports>
     //<compUnitImports> (Imp:Map => update(Imp, X |-> Class)) </compUnitImports>
     <classType> Class </classType>
     <classAccessMode> public </classAccessMode>

--- a/src/prep/process-local-classes.k
+++ b/src/prep/process-local-classes.k
@@ -305,10 +305,11 @@ when
     notBool haveUnaugmentedConstructors(ConsName, LocalEnvClass, Methods) ==K true
 
 syntax KItem ::= haveUnaugmentedConstructors( Id, ClassType, Map )                [function]
-rule haveUnaugmentedConstructors(ConsName:Id, LocalEnvClass:ClassType,
-                                 (sig(ConsName:Id, types(TList:KList)) |-> _) _:Map) => true
-when
-    notBool getLastKListElement([TList]) ==K LocalEnvClass
+//todo mapItem
+//rule haveUnaugmentedConstructors(ConsName:Id, LocalEnvClass:ClassType,
+//                                 (sig(ConsName:Id, types(TList:KList)) |-> _) _:Map) => true
+//when
+//    notBool getLastKListElement([TList]) ==K LocalEnvClass
 
 //@ Elaborates the given node and saves it to <elabBuffer>
 syntax KItem ::= appendToElabBuffer ( K ) //[strict, context(result(ElabKResult))] //K bug generalized strictness

--- a/src/prep/process-local-classes.k
+++ b/src/prep/process-local-classes.k
@@ -305,11 +305,26 @@ when
     notBool haveUnaugmentedConstructors(ConsName, LocalEnvClass, Methods) ==K true
 
 syntax KItem ::= haveUnaugmentedConstructors( Id, ClassType, Map )                [function]
-//todo mapItem
+syntax KItem ::= haveUnaugmentedConstructors( Id, ClassType, Signature, Map )     [function]
+//todo mapItem/solution proposed
 //rule haveUnaugmentedConstructors(ConsName:Id, LocalEnvClass:ClassType,
 //                                 (sig(ConsName:Id, types(TList:KList)) |-> _) _:Map) => true
 //when
 //    notBool getLastKListElement([TList]) ==K LocalEnvClass
+rule [haveUnaugmentedConstructorsConversion]:
+    haveUnaugmentedConstructors(I:Id, C:ClassType, (Key:Signature |-> _) Remains:Map) =>
+    haveUnaugmentedConstructors(I, C, Key, Remains)
+
+rule haveUnaugmentedConstructors(ConsName:Id, LocalEnvClass:ClassType,
+                                 sig(ConsName:Id, types(TList:KList)), _:Map) => true
+when
+    notBool getLastKListElement([TList]) ==K LocalEnvClass
+
+rule haveUnaugmentedConstructors(ConsName:Id, LocalEnvClass:ClassType,
+                                 sig(ConsName:Id, types(TList:KList)), Remains:Map) =>
+     haveUnaugmentedConstructors(ConsName, LocalEnvClass, Remains)
+when
+     getLastKListElement([TList]) ==K LocalEnvClass
 
 //@ Elaborates the given node and saves it to <elabBuffer>
 syntax KItem ::= appendToElabBuffer ( K ) //[strict, context(result(ElabKResult))] //K bug generalized strictness

--- a/src/prep/process-local-classes.k
+++ b/src/prep/process-local-classes.k
@@ -50,7 +50,7 @@ rule [processLocalClassDec-register-name]:
       )
       ...
     </k>
-    <localTypes> ListItem(mapWrap(LocalTypes:Map => LocalTypes[GeneratedClass / InitName])) ...</localTypes>
+    <localTypes> ListItem(mapWrap(LocalTypes:Map => LocalTypes[InitName <- GeneratedClass])) ...</localTypes>
     <contextType> CT:ContextType </contextType>
 
 //@ The second argument: existing modifiers

--- a/src/prep/process-type-names.k
+++ b/src/prep/process-type-names.k
@@ -9,6 +9,7 @@ module PROCESS-TYPE-NAMES
     imports AUX-STRINGS // for retainTail
     imports CORE-PREPROCESSING
 
+
 /*@ \subsection{Start of the phase ProcTypeNamesPhase}*/
 
 //Initial command for the preprocessing semantics
@@ -76,7 +77,7 @@ syntax KItem ::=  processTypeNames (
 
 rule [processTypeNames-AddPackage]:
     <k> processTypeNames(_, PackId:PackageId) ...</k>
-    <namesToClasses> PackMap:Map => PackMap[mapWrap(.Map) / PackId] </namesToClasses>
+    <namesToClasses> PackMap:Map => PackMap[PackId <- mapWrap(.Map)] </namesToClasses>
 when notBool PackId in keys(PackMap)
 
 /*@ May be both class or interface name. Anonymous labels will be one of:
@@ -94,7 +95,7 @@ rule [processTypeNames]:
     <namesToClasses>
       ...
       PackId |-> mapWrap(
-        ClassesMap:Map => ClassesMap[getClassType(PackId,SimpleClass) / SimpleClass]
+        ClassesMap:Map => ClassesMap[SimpleClass <- getClassType(PackId,SimpleClass)]
       )
       ...
     </namesToClasses>


### PR DESCRIPTION
Problems dealing with here are listed in wiki. Most parts are changed to accommodate new backend.
I moved two subsections from core-classes.k to core-functions.k to break circular imports.
1. aux function setUnion in core-functions.k needs to be done/or replaced by set builtin function (now commented); another commented function mapDiff is actually not used, so can ignore for now
2. need to check if the rule related to k bug as Denis commented is still needed (in elaboration-core.k)