### PR TITLE
invoke a hook function to print java's double

### DIFF
--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -13,7 +13,7 @@ rule toString(Str:String :: _) => Str
 rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
-rule toString(Fl:Float :: _) => Float2String(Fl)
+rule toString(Fl:Float :: _) => JavaFloat2String(Fl)
 rule toString(true::_) => "true"
 rule toString(false::_) => "false"
 rule toString(null::_) => "null"


### PR DESCRIPTION
@laurayuwen Quite simple change: the function "JavaFloat2String" is defined in K and I also made a pull request there.