### PR TITLE
Krun

### DIFF
--- a/src/exec/math.k
+++ b/src/exec/math.k
@@ -120,6 +120,8 @@ rule ok2PrintFloat(F:Float, N:Int) => inTheRange(nextDown(F), Float2String(F,
 
 rule numOfDigitsPreserved(Fl:Float) => numOfDigitsPreserved2(Fl, 17)
 
+rule numOfDigitsPreserved2(Fl:Float, 0) => 0
+
 rule numOfDigitsPreserved2(Fl:Float, N:Int) => numOfDigitsPreserved2(Fl, N -Int 1)
  when ok2PrintFloat(Fl, N)
 

--- a/src/exec/math.k
+++ b/src/exec/math.k
@@ -100,7 +100,7 @@ rule numOfDigitsPreserved2(F0:String, F1:String, F2:String)
                          getFractionalPart(F2))
 
 rule numOfDigitsPreserved3(F0:String, F1:String, F2:String)
-    => maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2))
+    => minInt(17, maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2)))
 
 
 

--- a/src/exec/math.k
+++ b/src/exec/math.k
@@ -1,0 +1,109 @@
+module JAVA-MATH
+
+syntax Int ::= uvalueMInt(MInt)     [function, hook(#MINT:uvalue), smtlib(bv2int)]
+
+// the min val of double in java
+syntax Float ::= "DoubleMinVal" | "DoubleMaxVal"
+syntax Float ::= "DoubleNegInf" | "DoublePosInf"
+syntax Float ::= "DoubleNaN"
+
+rule DoubleMinVal => minValueFloat(53, 11)
+rule DoubleMaxVal => maxValueFloat(53, 11)
+rule DoubleNegInf => minusInfinity(53, 11)
+rule DoublePosInf => plusInfinity(53, 11)
+rule DoubleNaN => fpNaN(53, 11)
+
+syntax Float ::= nextUp(Float) [function]
+syntax Float ::= nextDown(Float) [function]
+
+//FFFFFFFFFFFFF is eq to 4503599627370495
+//auxiliary functions for computing ajacent double values.
+syntax Float ::= incF0(String, Int) [function]
+                   //three args are prefix, significand, and power resp.
+               | incF1(String, Int, Int) [function]
+
+               | decF0(String, Int) [function]
+               //three args are prefix, significand, and power resp.
+               | decF1(String, Int, Int) [function]
+
+//there are 14 chars in the hex str, first 1 is either 0 or 1, the remaining 13 are significands.
+rule incF0(Fl:String, E:Int) => incF1(substrString(Fl, 0, 1), String2Base(substrString(Fl, 1,
+lengthString(Fl)), 16), E)
+
+
+rule incF1(Prefix:String, Significand:Int, Power:Int) =>
+String2Float("0x" +String Prefix +String ".0" +String "p" +String Int2String(Power +Int 1))
+when Significand ==Int 4503599627370495
+
+rule incF1(Prefix:String, Significand:Int, Power:Int) =>
+String2Float("0x" +String Prefix +String "." +String pad0(Base2String(Significand +Int 1, 16)) +String
+ "p" +String Int2String(Power))
+when notBool (Significand ==Int 4503599627370495)
+
+
+//=============auxiliary functions for computing next smaller double
+rule decF0(Fl:String, E:Int) => decF1(substrString(Fl, 0, 1), String2Base(substrString(Fl, 1,
+lengthString(Fl)), 16), E)
+
+
+rule decF1(Prefix:String, Significand:Int, Power:Int) =>
+String2Float("0x" +String Prefix +String ".FFFFFFFFFFFFF" +String "p" +String Int2String(Power -Int
+ 1)) when Significand ==Int 0
+
+rule decF1(Prefix:String, Significand:Int, Power:Int) =>
+String2Float("0x" +String Prefix +String "." +String pad0(Base2String(Significand -Int 1, 16))
++String "p" +String Int2String(Power))
+when notBool (Significand ==Int 0)
+
+
+//build the hex string of a float, given its significand's string and exponent.
+//syntax String ::= buildFloatHexStr(String, Int) [function]
+
+rule nextUp(DoubleNaN) => DoubleNaN
+rule nextUp(DoublePosInf) => DoublePosInf
+rule nextUp(0.0) => DoubleMinVal
+rule nextUp(Fl:Float) => incF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
+                            exponentFloat(Fl)) [owise]
+
+rule nextDown(DoubleNaN) => DoubleNaN
+rule nextDown(DoubleNegInf) => DoubleNegInf
+rule nextDown(0.0) => --Float DoubleMinVal
+rule nextDown(Fl:Float) => decF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
+                           exponentFloat(Fl)) [owise]
+
+
+
+/*@
+1. compute the diffFromPos value for the target doubleVal and its two adjacent values.
+    Say pos1 and pos2 representing the positions at which the target double value
+     can be distinguished with its next lower / next higher double value.
+2. return the larger one between pos1 and pos2.
+*/
+syntax Int ::= numOfDigitsPreserved(Float)  [function]
+            | numOfDigitsPreserved1(Float, Float, Float) [function]
+            //the string representation of the format "%.17Rf"
+            | numOfDigitsPreserved2(String, String, String) [function]
+            //the substr after decimal points: all of them should have 17 chars
+            | numOfDigitsPreserved3(String, String, String) [function]
+
+syntax String ::= getFractionalPart(String)  [function]
+rule getFractionalPart(S:String) =>
+    substrString(S, findChar(S, ".", 0) +Int 1, lengthString(S))
+
+rule numOfDigitsPreserved(Fl:Float) =>
+  numOfDigitsPreserved1(nextDown(Fl), Fl, nextUp(Fl))
+
+rule numOfDigitsPreserved1(F0:Float, F1:Float, F2:Float)
+     => numOfDigitsPreserved2(Float2String(F0, "%.18Rf"),
+                              Float2String(F1, "%.18Rf"),
+                              Float2String(F2, "%.18Rf"))
+
+rule numOfDigitsPreserved2(F0:String, F1:String, F2:String)
+    => numOfDigitsPreserved3(getFractionalPart(F0),
+                         getFractionalPart(F1),
+                         getFractionalPart(F2))
+
+rule numOfDigitsPreserved3(F0:String, F1:String, F2:String)
+    => maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2))
+
+endmodule

--- a/src/exec/math.k
+++ b/src/exec/math.k
@@ -13,8 +13,10 @@ rule DoubleNegInf => minusInfinity(53, 11)
 rule DoublePosInf => plusInfinity(53, 11)
 rule DoubleNaN => fpNaN(53, 11)
 
-syntax Float ::= nextUp(Float) [function]
-syntax Float ::= nextDown(Float) [function]
+syntax Float ::= nextUpPos(Float) [function]
+               | nextUp(Float)     [function]
+syntax Float ::= nextDownPos(Float) [function]
+               | nextDown(Float)     [function]
 
 //FFFFFFFFFFFFF is eq to 4503599627370495
 //auxiliary functions for computing ajacent double values.
@@ -59,16 +61,28 @@ when notBool (Significand ==Int 0)
 //build the hex string of a float, given its significand's string and exponent.
 //syntax String ::= buildFloatHexStr(String, Int) [function]
 
-rule nextUp(DoubleNaN) => DoubleNaN
-rule nextUp(DoublePosInf) => DoublePosInf
-rule nextUp(0.0) => DoubleMinVal
-rule nextUp(Fl:Float) => incF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
+rule nextUp(Fl:Float) => --Float nextDownPos(Fl)
+when signFloat(Fl)
+
+rule nextUp(Fl:Float) => nextUpPos(Fl)
+[owise]
+
+rule nextUpPos(DoubleNaN) => DoubleNaN
+rule nextUpPos(DoublePosInf) => DoublePosInf
+rule nextUpPos(0.0) => DoubleMinVal
+rule nextUpPos(Fl:Float) => incF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
                             exponentFloat(Fl)) [owise]
 
-rule nextDown(DoubleNaN) => DoubleNaN
-rule nextDown(DoubleNegInf) => DoubleNegInf
-rule nextDown(0.0) => --Float DoubleMinVal
-rule nextDown(Fl:Float) => decF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
+rule nextDown(Fl:Float) => --Float nextUpPos(Fl)
+when signFloat(Fl)
+
+rule nextDown(Fl:Float) => nextDownPos(Fl)
+[owise]
+
+rule nextDownPos(DoubleNaN) => DoubleNaN
+rule nextDownPos(DoubleNegInf) => DoubleNegInf
+rule nextDownPos(0.0) => --Float DoubleMinVal
+rule nextDownPos(Fl:Float) => decF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
                            exponentFloat(Fl)) [owise]
 
 

--- a/src/exec/math.k
+++ b/src/exec/math.k
@@ -80,30 +80,37 @@ rule nextDown(Fl:Float) => decF0(Base2String(uvalueMInt(significandFloat(Fl)), 1
 2. return the larger one between pos1 and pos2.
 */
 syntax Int ::= numOfDigitsPreserved(Float)  [function]
-            | numOfDigitsPreserved1(Float, Float, Float) [function]
-            //the string representation of the format "%.17Rf"
-            | numOfDigitsPreserved2(String, String, String) [function]
-            //the substr after decimal points: all of them should have 17 chars
-            | numOfDigitsPreserved3(String, String, String) [function]
+syntax Int ::= numOfDigitsPreserved2(Float, Int)  [function]
 
-rule numOfDigitsPreserved(Fl:Float) =>
-  numOfDigitsPreserved1(nextDown(Fl), Fl, nextUp(Fl))
+//The string arg in the middle is the string representation a float.
+syntax Bool ::= inTheRange(Float, String, Float)  [function]
+syntax Bool ::= inTheRange2(Float, Float, Float)  [function]
 
-rule numOfDigitsPreserved1(F0:Float, F1:Float, F2:Float)
-     => numOfDigitsPreserved2(Float2String(F0, "%.18Rf"),
-                              Float2String(F1, "%.18Rf"),
-                              Float2String(F2, "%.18Rf"))
+//check whether it is ok to use the format str "%." +String Int2String(N) +String "Rg"
+//to print the float F so that the float F' (transformed back from the printed string)
+//has the property:  nextDown(F) < F' < nextUp(F)
+syntax Bool ::= ok2PrintFloat(Float, Int) [function]
 
-rule numOfDigitsPreserved2(F0:String, F1:String, F2:String)
-    => numOfDigitsPreserved3(getFractionalPart(F0),
-                         getFractionalPart(F1),
-                         getFractionalPart(F2))
+rule inTheRange(F1:Float, F2:String, F3:Float) => inTheRange2(F1, String2Float(F2), F3)
 
-rule numOfDigitsPreserved3(F0:String, F1:String, F2:String)
-    => minInt(17, maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2)))
+rule inTheRange2(F1:Float, F2:Float, F3:Float) => true
+when F1 <Float F2 andBool F2 <Float F3
+
+rule inTheRange2(F1:Float, F2:Float, F3:Float) => false
+[owise]
+
+rule ok2PrintFloat(F:Float, N:Int) => inTheRange(nextDown(F), Float2String(F,
+            "%." +String Int2String(N) +String "Rg") , nextUp(F))
 
 
 
+rule numOfDigitsPreserved(Fl:Float) => numOfDigitsPreserved2(Fl, 17)
+
+rule numOfDigitsPreserved2(Fl:Float, N:Int) => numOfDigitsPreserved2(Fl, N -Int 1)
+ when ok2PrintFloat(Fl, N)
+
+rule numOfDigitsPreserved2(Fl:Float, N:Int) => N +Int 1
+[owise]
 
 //add 0 to the beginning of the hex string to make it 13 digits.
 //the int arg is the number of zero to be added.

--- a/src/exec/math.k
+++ b/src/exec/math.k
@@ -86,10 +86,6 @@ syntax Int ::= numOfDigitsPreserved(Float)  [function]
             //the substr after decimal points: all of them should have 17 chars
             | numOfDigitsPreserved3(String, String, String) [function]
 
-syntax String ::= getFractionalPart(String)  [function]
-rule getFractionalPart(S:String) =>
-    substrString(S, findChar(S, ".", 0) +Int 1, lengthString(S))
-
 rule numOfDigitsPreserved(Fl:Float) =>
   numOfDigitsPreserved1(nextDown(Fl), Fl, nextUp(Fl))
 
@@ -105,5 +101,47 @@ rule numOfDigitsPreserved2(F0:String, F1:String, F2:String)
 
 rule numOfDigitsPreserved3(F0:String, F1:String, F2:String)
     => maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2))
+
+
+
+
+//add 0 to the beginning of the hex string to make it 13 digits.
+//the int arg is the number of zero to be added.
+syntax String ::=     pad0(String)      [function]
+                    | pad0(String, Int) [function]
+
+rule pad0(S:String) => pad0(S, 13 -Int lengthString(S))
+
+rule pad0(S:String, I:Int) => S
+when I <=Int 0
+
+rule pad0(S:String, I:Int) => pad0("0" +String S, I -Int 1)
+when I >Int 0
+
+syntax String ::= getFractionalPart(String)  [function]
+rule getFractionalPart(S:String) =>
+    substrString(S, findChar(S, ".", 0) +Int 1, lengthString(S))
+
+/*@auxiliary function for printing Java's double value in default mode.
+//the number of digits preserved after decimal point depend solely on whether
+// that amount of significands can distinguish the target value with its adjacent
+//double values.
+//This function returns the pos at which two strings are distinguishable
+//the two input string are assumed to have equal length.
+*/
+syntax Int ::= diffFromPos(String, String) [function]
+
+rule diffFromPos(S1:String, S2:String) => 0
+    when S1 ==String "" orBool S2 ==String ""
+
+rule diffFromPos(S1:String, S2:String) => 1
+    when substrString(S1, 0, 1) =/=String substrString(S2, 0, 1)
+
+rule diffFromPos(S1:String, S2:String) =>
+    1 +Int diffFromPos(substrString(S1, 1, lengthString(S1)),
+                    substrString(S2, 1, lengthString(S2)))
+    when substrString(S1, 0, 1) ==String substrString(S2, 0, 1)
+
+rule diffFromPos(S1:String, S2:String) => -1 [owise] //error state
 
 endmodule

--- a/src/exec/math.k
+++ b/src/exec/math.k
@@ -105,6 +105,8 @@ syntax Bool ::= inTheRange2(Float, Float, Float)  [function]
 //has the property:  nextDown(F) < F' < nextUp(F)
 syntax Bool ::= ok2PrintFloat(Float, Int) [function]
 
+syntax Bool ::= ok2PrintFloatStr(Float, String, Float)  [function]
+
 rule inTheRange(F1:Float, F2:String, F3:Float) => inTheRange2(F1, String2Float(F2), F3)
 
 rule inTheRange2(F1:Float, F2:Float, F3:Float) => true
@@ -113,17 +115,19 @@ when F1 <Float F2 andBool F2 <Float F3
 rule inTheRange2(F1:Float, F2:Float, F3:Float) => false
 [owise]
 
-rule ok2PrintFloat(F:Float, N:Int) => inTheRange(nextDown(F), Float2String(F,
-            "%." +String Int2String(N) +String "Rg") , nextUp(F))
+rule ok2PrintFloat(F:Float, N:Int) => ok2PrintFloatStr(nextDown(F), Float2String(F,
+            "%." +String Int2String(N) +String "Rg"), nextUp(F))
 
-
+//it is ok to print if it is in the interval (nextDown, nextUp) and it is not in scientific
+//notation : no "e+" or "e-" symbol inside...
+rule ok2PrintFloatStr(F1:Float, F2:String, F3:Float) =>
+    inTheRange(F1, F2, F3) andBool findString(F2, "e+", 0) <Int 0 andBool findString(F2, "e-", 0)
+    <Int 0
 
 rule numOfDigitsPreserved(Fl:Float) => numOfDigitsPreserved2(Fl, 17)
 
-rule numOfDigitsPreserved2(Fl:Float, 0) => 0
-
 rule numOfDigitsPreserved2(Fl:Float, N:Int) => numOfDigitsPreserved2(Fl, N -Int 1)
- when ok2PrintFloat(Fl, N)
+ when ok2PrintFloat(Fl, N) andBool N >=Int 1
 
 rule numOfDigitsPreserved2(Fl:Float, N:Int) => N +Int 1
 [owise]

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -30,23 +30,21 @@ http://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#toString(double)
     distinguishable, then Candidate 1 will be returned as the string representation of the
     target double value, otherwise, Candidate 2 will be returned.
 */
-syntax String ::= //add special checks: if the output is an int, then add ".0" at the end
-                  javaDouble2String(Float)   [function]
-                | javaDouble2String1(Float)  [function]
-                | javaDouble2StringCheck(String)  [function]
+syntax String ::= javaDouble2String(Float)   [function]
+                | javaDouble2StringWithCheck(Float)  [function]
+                | addDot0AtTheEnd(String)  [function]
 
                    //The three args are lower bound low, target float, upper bound high,
                    //If the absolute value of the target float is inside the range [low,high),
         //then it will be printed in decimal format, owise, scientific notation will be used.
                 | javaDouble2StringAux(Float, Float, Float)  [function]
-                | check0(String, Bool) [function]
 
 
-rule javaDouble2String1(DoubleNegInf) => "-Infinity"
-rule javaDouble2String1(DoublePosInf) => "Infinity"
-rule javaDouble2String1(DoubleNaN) => "NaN"
+rule javaDouble2String(DoubleNegInf) => "-Infinity"
+rule javaDouble2String(DoublePosInf) => "Infinity"
+rule javaDouble2String(DoubleNaN) => "NaN"
 
-rule javaDouble2String1(Fl:Float) => javaDouble2StringAux(10.0^Float(-3.0), Fl, 10.0^Float(7.0))
+rule javaDouble2String(Fl:Float) => javaDouble2StringAux(10.0^Float(-3.0), Fl, 10.0^Float(7.0))
 [owise]
 
 rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) =>
@@ -60,12 +58,12 @@ rule javaDouble2StringAux(_, --Float 0.0, _) => "-0.0"
 //The other double numbers should be printed in "ScientificNotation".
 rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) => Float2String(Fl, "%Re") [owise]
 
-rule javaDouble2String(Fl:Float) => javaDouble2StringCheck(javaDouble2String1(Fl))
+rule javaDouble2StringWithCheck(Fl:Float) => addDot0AtTheEnd(javaDouble2String(Fl))
 
-rule javaDouble2StringCheck(Fl:String) => Fl
+rule addDot0AtTheEnd(Fl:String) => Fl
 when findChar(Fl, ".", 0) >=Int 0
 
-rule javaDouble2StringCheck(Fl:String) => Fl +String ".0"
+rule addDot0AtTheEnd(Fl:String) => Fl +String ".0"
 [owise]
 
 /*@ Converts all possible Java values into String. Used mostly for printing and String + operator.
@@ -79,18 +77,25 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) => javaDouble2String(Fl)
+rule toString(Fl:Float :: _) => javaDouble2StringWithCheck(Fl)
+
+//"\n.1Rg: " +String Float2String(Fl, "%.1Rg")
+//+String "\n.2Rg: " +String Float2String(Fl, "%.2Rg")
+//+String "\n.15Rg: " +String Float2String(Fl, "%.15Rg")
+//+String "\nSignificand: " +String Base2String(uvalueMInt(significandFloat(Fl)), 16)
+//javaDouble2String(Fl)
+
+//%.0Rg may print the number in scientific notation unexpectedly!
+//Float2String(Fl)
+//+String "\n.15Rg: " +String Float2String(Fl, "%.15Rg")
+//+String "\nMy: " +String javaDouble2String(Fl)
+//+String "\n.0Rg: " +String Float2String(Fl, "%.0Rg")
+//javaDouble2String(Fl)
 
 //Float2String(Fl, "%Re") +String ";\n" +String Float2String(Fl, "%.18Rf")
 // +String ";\nnextDown: " +String Float2String(nextDown(Fl), "%.18Rf")
 // +String ";\nnextUp: " +String Float2String(nextUp(Fl), "%.18Rf")
-// +String ";\nmy: " +String javaDouble2String1(Fl)
-
-//toString(isDiffFl(nextDown(7.0 /Float 1.2), "5.83333333333333", nextUp(7.0 /Float 1.2)))
-//
-//toString(isDiffFl(nextDown(0.017), "0.017000000000000001", nextUp(0.017)))
-
-//javaDouble2String1(Fl)
+// +String ";\nmy: " +String javaDouble2String(Fl)
 
 //java: 9.0E-4
 /*
@@ -99,8 +104,6 @@ Float2String(0.0009, "%Re") +String ";\t" +String Float2String(0.0009, "%.15Re")
   +String ";\t" +String Float2String(0.0009, "%.17Re")
   +String ";\n" +String  chooseFromCandidateDoubleStr0(nextDown(0.0009), 0.0009, nextUp(0.0009))
 */
-//javaDouble2String1(Fl)
-
 
 rule toString(true::_) => "true"
 rule toString(false::_) => "false"

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -39,6 +39,10 @@ syntax Float ::= incF0(String, Int) [function]
                    //three args are prefix, significand, and power resp.
                | incF1(String, Int, Int) [function]
 
+               | decF0(String, Int) [function]
+               //three args are prefix, significand, and power resp.
+               | decF1(String, Int, Int) [function]
+
 //there are 14 chars in the hex str, first 1 is either 0 or 1, the remaining 13 are significands.
 rule incF0(Fl:String, E:Int) => incF1(substrString(Fl, 0, 1), String2Base(substrString(Fl, 1,
 lengthString(Fl)), 16), E)
@@ -53,6 +57,22 @@ String2Float("0x" +String Prefix +String "." +String pad0(Base2String(Significan
  "p" +String Int2String(Power))
 when notBool (Significand ==Int 4503599627370495)
 
+
+//=============auxiliary functions for computing next smaller double
+rule decF0(Fl:String, E:Int) => decF1(substrString(Fl, 0, 1), String2Base(substrString(Fl, 1,
+lengthString(Fl)), 16), E)
+
+
+rule decF1(Prefix:String, Significand:Int, Power:Int) =>
+String2Float("0x" +String Prefix +String ".FFFFFFFFFFFFF" +String "p" +String Int2String(Power -Int
+ 1)) when Significand ==Int 0
+
+rule decF1(Prefix:String, Significand:Int, Power:Int) =>
+String2Float("0x" +String Prefix +String "." +String pad0(Base2String(Significand -Int 1, 16))
++String "p" +String Int2String(Power))
+when notBool (Significand ==Int 0)
+
+
 //build the hex string of a float, given its significand's string and exponent.
 //syntax String ::= buildFloatHexStr(String, Int) [function]
 
@@ -65,7 +85,8 @@ rule nextUp(Fl:Float) => incF0(Base2String(uvalueMInt(significandFloat(Fl)), 16)
 rule nextDown(DoubleNaN) => DoubleNaN
 rule nextDown(DoubleNegInf) => DoubleNegInf
 rule nextDown(0.0) => --Float DoubleMinVal
-rule nextDown(Fl:Float) => 0.0 [owise]
+rule nextDown(Fl:Float) => decF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
+                                                       exponentFloat(Fl)) [owise]
 
 syntax String ::= fst17AfterDot(Float) [function]
 rule fst17AfterDot(Fl) => Float2String(Fl, "%.22Rf")
@@ -80,7 +101,10 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) => Float2String(nextUp(Fl), "%Ra")
+rule toString(Fl:Float :: _) => Float2String(nextUp(Fl), "%Ra") +String ";;\t"
+ +String Float2String(Fl, "%RA") +String ";;\t" +String
+Float2String(nextDown(Fl), "%RA") +String ";;\tone down's Float\t" +String
+                                  Float2String(String2Float("0x1.fffffffffffffp-1"), "%RA")
 
 //Float2String(incF0("10000000000000",0), "%Ra")
 

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -45,8 +45,9 @@ syntax String ::= javaDouble2String(Float)  [function]
 
                 //the 4 args are: nextDown, nextUp, candidate1, candidate2
                 //At first, the candidate1 is transformed back to float and compare with its
-                //neighbors, if ok then return it, owise return the candidate2
-                | chooseFromCandidateDoubleStr2(Float, Float, String, String) [function]
+                //neighbors, if ok then return it, owise tries the candidate2, then candidate3...
+                | chooseFromCandidateDoubleStr2(Float, Float, String, String, String) [function]
+                | chooseFromCandidateDoubleStr3(Float, Float, String, String) [function]
 
                 | check0(String, Bool) [function]
 
@@ -72,7 +73,8 @@ when (Fl >=Float Low andBool Fl <Float High) orBool
 rule javaDouble2StringAux(_, 0.0, _) => "0.0"
 rule javaDouble2StringAux(_, --Float 0.0, _) => "-0.0"
 
-rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) => "ScientificNotation" [owise]
+//The other double numbers should be printed in "ScientificNotation".
+rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) => Float2String(Fl, "%Re") [owise]
 
 
 rule chooseFromCandidateDoubleStr0(F0:Float, F1:Float, F2:Float) =>
@@ -80,14 +82,23 @@ rule chooseFromCandidateDoubleStr0(F0:Float, F1:Float, F2:Float) =>
 
 rule chooseFromCandidateDoubleStr1(Lower:Float, Cur:Float, Higher:Float, N:Int) =>
     chooseFromCandidateDoubleStr2(Lower, Higher,
+                            Float2String(Cur, "%." +String Int2String(N -Int 1) +String "Rg"),
                             Float2String(Cur, "%." +String Int2String(N) +String "Rg"),
                             Float2String(Cur, "%." +String Int2String(N +Int 1) +String "Rg"))
 
 
-rule chooseFromCandidateDoubleStr2(Lower:Float, Higher:Float, Cand1:String, Cand2:String) => Cand1
+rule chooseFromCandidateDoubleStr2(Lower:Float, Higher:Float, Cand1:String, Cand2:String,
+Cand3:String) => Cand1
 when isDiffFl(Lower, Cand1, Higher)
 
-rule chooseFromCandidateDoubleStr2(Lower:Float, Higher:Float, Cand1:String, Cand2:String) => Cand2
+rule chooseFromCandidateDoubleStr2(Lower:Float, Higher:Float, Cand1:String, Cand2:String,
+Cand3:String) => chooseFromCandidateDoubleStr3(Lower:Float, Higher:Float, Cand2, Cand3)
+[owise]
+
+rule chooseFromCandidateDoubleStr3(Lower:Float, Higher:Float, Cand2:String, Cand3:String) => Cand2
+when isDiffFl(Lower, Cand2, Higher)
+
+rule chooseFromCandidateDoubleStr3(Lower:Float, Higher:Float, Cand2:String, Cand3:String) => Cand3
 [owise]
 
 /*@ Converts all possible Java values into String. Used mostly for printing and String + operator.
@@ -102,6 +113,24 @@ rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
 rule toString(Fl:Float :: _) => javaDouble2String(Fl)
+//toString(isDiffFl(nextDown(0.017), "0.017000000000000001", nextUp(0.017)))
+
+//javaDouble2String(Fl)
+/*
+"0.017 in hex str: " +String
+Float2String(0.017, "%Re") +String ";\n0.017 in 18 digits:" +String Float2String(0.017, "%.18Rf")
+ +String ";\n0.017's next down:" +String Float2String(nextDown(0.017), "%.18Rf")
+ +String ";\n0.017's next up:" +String Float2String(nextUp(0.017), "%.18Rf")
+ +String ";\n0.017 my out: " +String javaDouble2String(0.017)
+ +String ";\nNumOfDigitsPreserved is " +String Int2String(numOfDigitsPreserved(0.017))
+ +String ";\nString2Float: " +String Float2String(String2Float("0.017000000000000001"))
+ +String ";\nString2Float: " +String Float2String(String2Float("1.7000000000000001e-02"))
+ +String ";\nString of nextUp: " +String Float2String(String2Float("0.017000000000000005"))
+ +String "\n=? "
+ //when (( (nextDown(0.017)) =/=Float (String2Float("0.017000000000000001")) ))
+ // (( (nextUp(0.017)) =/=Float (String2Float("0.017000000000000001")) ))
+*/
+
 //java: 9.0E-4
 /*
 Float2String(0.0009, "%Re") +String ";\t" +String Float2String(0.0009, "%.15Re")

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -180,7 +180,7 @@ when X >=Int 5 andBool (B +Int 1 <Int 10^N)
 //inc by one unit, has overflow in fractional part
 rule incI(A:Int, B:Int, X:Int, N:Int) =>
 incNoOverflow(Int2String(A +Int 1), "0", 1)
-when X >=Int 5 andBool (B +Int 1 >=Int 10^N)
+when X >=Int 5 andBool (B +Int 1 >=Int 10 ^Int N)
 
 
 rule incNoOverflow(A:String, B:String, N:Int) =>
@@ -196,7 +196,7 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) =>
+rule toString(Fl:Float :: _) => round(Float2String(Fl, "%.18Rf"), numOfDigitsPreserved(Fl))
 
 
 

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -146,56 +146,42 @@ rule numOfDigitsPreserved3(F0:String, F1:String, F2:String)
     => maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2))
 
 
-//Implement the rounding mode of 'N' (round to nearest) manually in order to pass the tests.
-//round(s,i) where s is the target float number in string format and int i is the number of
-//fractional digits after the decimal point;
-syntax String ::= round0(String, Int) [function]
-                //use this helper method so that only compute the pos of decimal point one time
-                //the arg in the middle is the pos of "."
-                | round1(String, Int, Int) [function]
+syntax String ::= javaDouble2String(Float)  [function]
+//the three args: nextDown, target double, nextUp
+                | chooseFromCandidateDoubleStr0(Float, Float, Float) [function]
 
- //The method incI analyzes a float string in this format: A.BX, where X is the last digit
- //and the length of B is the number of preserved fractional digits (denoted by n)
- //The four args are A, B, X, n
-                | incI(Int, Int, Int, Int)  [function]
-                //helper function to avoid the repetition of computation
-                | incNoOverflow(String, String, Int)  [function]
+//First three args are the same as the above function, the last one is the number at which pos the
+//target double is distinguishable from its adjacent double values
+                | chooseFromCandidateDoubleStr1(Float, Float, Float, Int) [function]
+
+                //the 4 args are: nextDown, nextUp, candidate1, candidate2
+                //At first, the candidate1 is transformed back to float and compare with its
+                //neighbors, if ok then return it, owise return the candidate2
+                | chooseFromCandidateDoubleStr2(Float, Float, String, String) [function]
 
 
+//check whether the string (representing a float) is diff from both of the two floats.
+syntax Bool ::= isDiffFl(Float, String, Float) [function]
+               | isDiff(Float, Float, Float) [function]
+rule isDiffFl(F0:Float, F1:String, F2:Float) => isDiff(F0, String2Float(F1), F2)
+rule isDiff(F0:Float, F1:Float, F2:Float) => F1 =/=Float F0 andBool F1 =/=Float F2
 
-rule round0(S:String, N:Int) => round1(S, findChar(S, ".", 0), N)
+rule javaDouble2String(Fl:Float) => chooseFromCandidateDoubleStr0(nextDown(Fl), Fl, nextUp(Fl))
 
+rule chooseFromCandidateDoubleStr0(F0:Float, F1:Float, F2:Float) =>
+    chooseFromCandidateDoubleStr1(F0, F1, F2, numOfDigitsPreserved1(F0, F1, F2))
 
-
-rule round1(S:String, Pos:Int, N:Int) => incI(String2Int(substrString(S, 0, Pos)),
-                            String2Int(substrString(S, Pos +Int 1, Pos +Int 1 +Int N)),
-                            String2Int(substrString(S, Pos +Int 1 +Int N, Pos +Int 2 +Int N)),
-                             N)
-
-
-rule incI(A:Int, B:Int, X:Int, N:Int) =>
-incNoOverflow(Int2String(A), Int2String(B), N)
-when X <Int 5
-
-//inc by one unit, no overflow in fractional part
-rule incI(A:Int, B:Int, X:Int, N:Int) =>
-incNoOverflow(Int2String(A), Int2String(B +Int 1), N)
-when X >=Int 5 andBool (B +Int 1 <Int 10 ^Int N)
-
-//inc by one unit, has overflow in fractional part
-rule incI(A:Int, B:Int, X:Int, N:Int) =>
-incNoOverflow(Int2String(A +Int 1), "0", 1)
-when X >=Int 5 andBool (B +Int 1 >=Int 10 ^Int N)
+rule chooseFromCandidateDoubleStr1(Lower:Float, Cur:Float, Higher:Float, N:Int) =>
+    chooseFromCandidateDoubleStr2(Lower, Higher,
+                            Float2String(Cur, "%." +String Int2String(N) +String "Rg"),
+                            Float2String(Cur, "%." +String Int2String(N +Int 1) +String "Rg"))
 
 
+rule chooseFromCandidateDoubleStr2(Lower:Float, Higher:Float, Cand1:String, Cand2:String) => Cand1
+when isDiffFl(Lower, Cand1, Higher)
 
-rule incI(A:Int, B:Int, X:Int, N:Int) => "Error State!"
-[owise] //error state
-
-
-
-rule incNoOverflow(A:String, B:String, N:Int) =>
-  A +String "." +String pad0(B, N -Int lengthString(B))
+rule chooseFromCandidateDoubleStr2(Lower:Float, Higher:Float, Cand1:String, Cand2:String) => Cand2
+[owise]
 
 /*@ Converts all possible Java values into String. Used mostly for printing and String + operator.
     Conversion for other value forms is defined in other modules.
@@ -208,13 +194,7 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) =>
-//round0("100.99634", 2)
-//round1("100.99634", 3, 2)
-//"" +String incI(100,99,6,2)
-
-round0(Float2String(Fl, "%.18Rf"), numOfDigitsPreserved(Fl))
-
+rule toString(Fl:Float :: _) => javaDouble2String(Fl)
 
 
 /*
@@ -234,9 +214,6 @@ round0(Float2String(Fl, "%.18Rf"), numOfDigitsPreserved(Fl))
                       +String ";;\tTarget in round 18 RNf: " +String Float2String(Fl, "%.18RNf")
                       +String ";;\tTarget in round 18 RNg: " +String Float2String(Fl, "%.18RNg")
 
-
-
-//Float2String(incF0("10000000000000",0), "%Ra")
 
 
 Float2String(String2Float("0x" +String "1" +String "." +String Int2String(0 +Int 1)

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -30,7 +30,11 @@ http://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#toString(double)
     distinguishable, then Candidate 1 will be returned as the string representation of the
     target double value, otherwise, Candidate 2 will be returned.
 */
-syntax String ::= javaDouble2String(Float)  [function]
+syntax String ::= //add special checks: if the output is an int, then add ".0" at the end
+                  javaDouble2String(Float)   [function]
+                | javaDouble2String1(Float)  [function]
+                | javaDouble2StringCheck(String)  [function]
+
                    //The three args are lower bound low, target float, upper bound high,
                    //If the absolute value of the target float is inside the range [low,high),
         //then it will be printed in decimal format, owise, scientific notation will be used.
@@ -38,11 +42,11 @@ syntax String ::= javaDouble2String(Float)  [function]
                 | check0(String, Bool) [function]
 
 
-rule javaDouble2String(DoubleNegInf) => "-Infinity"
-rule javaDouble2String(DoublePosInf) => "Infinity"
-rule javaDouble2String(DoubleNaN) => "NaN"
+rule javaDouble2String1(DoubleNegInf) => "-Infinity"
+rule javaDouble2String1(DoublePosInf) => "Infinity"
+rule javaDouble2String1(DoubleNaN) => "NaN"
 
-rule javaDouble2String(Fl:Float) => javaDouble2StringAux(10.0^Float(-3.0), Fl, 10.0^Float(7.0))
+rule javaDouble2String1(Fl:Float) => javaDouble2StringAux(10.0^Float(-3.0), Fl, 10.0^Float(7.0))
 [owise]
 
 rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) =>
@@ -55,6 +59,14 @@ rule javaDouble2StringAux(_, --Float 0.0, _) => "-0.0"
 
 //The other double numbers should be printed in "ScientificNotation".
 rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) => Float2String(Fl, "%Re") [owise]
+
+rule javaDouble2String(Fl:Float) => javaDouble2StringCheck(javaDouble2String1(Fl))
+
+rule javaDouble2StringCheck(Fl:String) => Fl
+when findChar(Fl, ".", 0) >=Int 0
+
+rule javaDouble2StringCheck(Fl:String) => Fl +String ".0"
+[owise]
 
 /*@ Converts all possible Java values into String. Used mostly for printing and String + operator.
     Conversion for other value forms is defined in other modules.
@@ -72,13 +84,13 @@ rule toString(Fl:Float :: _) => javaDouble2String(Fl)
 //Float2String(Fl, "%Re") +String ";\n" +String Float2String(Fl, "%.18Rf")
 // +String ";\nnextDown: " +String Float2String(nextDown(Fl), "%.18Rf")
 // +String ";\nnextUp: " +String Float2String(nextUp(Fl), "%.18Rf")
-// +String ";\nmy: " +String javaDouble2String(Fl)
+// +String ";\nmy: " +String javaDouble2String1(Fl)
 
 //toString(isDiffFl(nextDown(7.0 /Float 1.2), "5.83333333333333", nextUp(7.0 /Float 1.2)))
 //
 //toString(isDiffFl(nextDown(0.017), "0.017000000000000001", nextUp(0.017)))
 
-//javaDouble2String(Fl)
+//javaDouble2String1(Fl)
 
 //java: 9.0E-4
 /*
@@ -87,7 +99,7 @@ Float2String(0.0009, "%Re") +String ";\t" +String Float2String(0.0009, "%.15Re")
   +String ";\t" +String Float2String(0.0009, "%.17Re")
   +String ";\n" +String  chooseFromCandidateDoubleStr0(nextDown(0.0009), 0.0009, nextUp(0.0009))
 */
-//javaDouble2String(Fl)
+//javaDouble2String1(Fl)
 
 
 rule toString(true::_) => "true"

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -96,16 +96,20 @@ rule nextDown(Fl:Float) => decF0(Base2String(uvalueMInt(significandFloat(Fl)), 1
 //the two input string are assumed to have equal length.
 */
 syntax Int ::= diffFromPos(String, String) [function]
-rule diffFromPos(S1:String, S2:String) => 1
-    when substrString(S1, 0, 1) =/=String substrString(S2, 0, 1)
 
 rule diffFromPos(S1:String, S2:String) => 0
     when S1 ==String "" orBool S2 ==String ""
 
+rule diffFromPos(S1:String, S2:String) => 1
+    when substrString(S1, 0, 1) =/=String substrString(S2, 0, 1)
+
 rule diffFromPos(S1:String, S2:String) =>
-    1 + diffFromPos(substrString(S1, 1, lengthString(S1)),
+    1 +Int diffFromPos(substrString(S1, 1, lengthString(S1)),
                     substrString(S2, 1, lengthString(S2)))
     when substrString(S1, 0, 1) ==String substrString(S2, 0, 1)
+
+rule diffFromPos(S1:String, S2:String) => -1 [owise] //error state
+
 
 /*@
 1. compute the diffFromPos value for the target doubleVal and its two adjacent values.
@@ -152,8 +156,14 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) => Float2String(Fl, "%." +String
-                      Int2String(numOfDigitsPreserved(Fl)) +String "RNg")
+rule toString(Fl:Float :: _) => Int2String(diffFromPos("1007","1017"))
+ +String "==3 && "
+ //+String getFractionalPart("12.527") +String "==527 && "
+ //   +String Int2String(numOfDigitsPreserved3("100000", "100011", "100012"))
+ //   +String " == 6"
+
+//Float2String(Fl, "%." +String
+//                      Int2String(numOfDigitsPreserved(Fl)) +String "RNg")
 
 //Float2String(incF0("10000000000000",0), "%Ra")
 

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -1,3 +1,5 @@
+require "math.k"
+
 module TO-STRING
     imports CORE-SORTS
     imports CORE-FUNCTIONS
@@ -6,41 +8,6 @@ module TO-STRING
     imports JAVA-MATH
 
 
-//add 0 to the beginning of the hex string to make it 13 digits.
-//the int arg is the number of zero to be added.
-syntax String ::=     pad0(String)      [function]
-                    | pad0(String, Int) [function]
-
-rule pad0(S:String) => pad0(S, 13 -Int lengthString(S))
-
-rule pad0(S:String, I:Int) => S
-when I <=Int 0
-
-rule pad0(S:String, I:Int) => pad0("0" +String S, I -Int 1)
-when I >Int 0
-
-
-/*@auxiliary function for printing Java's double value in default mode.
-//the number of digits preserved after decimal point depend solely on whether
-// that amount of significands can distinguish the target value with its adjacent
-//double values.
-//This function returns the pos at which two strings are distinguishable
-//the two input string are assumed to have equal length.
-*/
-syntax Int ::= diffFromPos(String, String) [function]
-
-rule diffFromPos(S1:String, S2:String) => 0
-    when S1 ==String "" orBool S2 ==String ""
-
-rule diffFromPos(S1:String, S2:String) => 1
-    when substrString(S1, 0, 1) =/=String substrString(S2, 0, 1)
-
-rule diffFromPos(S1:String, S2:String) =>
-    1 +Int diffFromPos(substrString(S1, 1, lengthString(S1)),
-                    substrString(S2, 1, lengthString(S2)))
-    when substrString(S1, 0, 1) ==String substrString(S2, 0, 1)
-
-rule diffFromPos(S1:String, S2:String) => -1 [owise] //error state
 
 /*@
 The algorithm for printing a Java's double value is based on the description of Javadoc of Double.

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -146,6 +146,14 @@ rule numOfDigitsPreserved3(F0:String, F1:String, F2:String)
     => maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2))
 
 
+
+syntax String ::= incNoOverflow(String, String, Int)  [function]
+                | incI(Int, Int, Int, Int)  [function]
+                | round1(String, Int, Int) [function]
+                | round0(String, Int) [function]
+
+
+/*
 //Implement the rounding mode of 'N' (round to nearest) manually in order to pass the tests.
 //round(s,i) where s is the target float number in string format and int i is the number of
 //fractional digits after the decimal point;
@@ -161,12 +169,17 @@ syntax String ::= round(String, Int) [function]
                 //helper function to avoid the repetition of computation
                 | incNoOverflow(String, String, Int)  [function]
 
-rule round(S:String, N:Int) => round1(S, findChar(S, ".", 0), N)
+           */
+
+rule round0(S:String, N:Int) => round1(S, findChar(S, ".", 0), N)
+
+
 
 rule round1(S:String, Pos:Int, N:Int) => incI(String2Int(substrString(S, 0, Pos)),
                             String2Int(substrString(S, Pos +Int 1, Pos +Int 1 +Int N)),
                             String2Int(substrString(S, Pos +Int 1 +Int N, Pos +Int 2 +Int N)),
                              N)
+
 
 rule incI(A:Int, B:Int, X:Int, N:Int) =>
 incNoOverflow(Int2String(A), Int2String(B), N)
@@ -175,12 +188,18 @@ when X <Int 5
 //inc by one unit, no overflow in fractional part
 rule incI(A:Int, B:Int, X:Int, N:Int) =>
 incNoOverflow(Int2String(A), Int2String(B +Int 1), N)
-when X >=Int 5 andBool (B +Int 1 <Int 10^N)
+when X >=Int 5 andBool (B +Int 1 <Int 10 ^Int N)
 
 //inc by one unit, has overflow in fractional part
 rule incI(A:Int, B:Int, X:Int, N:Int) =>
 incNoOverflow(Int2String(A +Int 1), "0", 1)
 when X >=Int 5 andBool (B +Int 1 >=Int 10 ^Int N)
+
+
+
+rule incI(A:Int, B:Int, X:Int, N:Int) => "Error State!"
+[owise] //error state
+
 
 
 rule incNoOverflow(A:String, B:String, N:Int) =>
@@ -189,6 +208,7 @@ rule incNoOverflow(A:String, B:String, N:Int) =>
 /*@ Converts all possible Java values into String. Used mostly for printing and String + operator.
     Conversion for other value forms is defined in other modules.
 */
+
 syntax Exp ::= toString ( K )   [strict]
 
 rule toString(Str:String :: _) => Str
@@ -196,7 +216,11 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) => round(Float2String(Fl, "%.18Rf"), numOfDigitsPreserved(Fl))
+rule toString(Fl:Float :: _) => round0("100.99634", 2)
+//round1("100.99634", 3, 2)
+//"" +String incI(100,99,6,2)
+
+//round(Float2String(Fl, "%.18Rf"), numOfDigitsPreserved(Fl))
 
 
 

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -5,8 +5,19 @@ module TO-STRING
     imports SYNTAX-CONVERSIONS
 
 
-  syntax Int ::= svalueMInt(MInt)     [function, hook(#MINT:svalue)]
-  | uvalueMInt(MInt)     [function, hook(#MINT:uvalue), smtlib(bv2int)]
+//add 0 to the beginning of the hex string to make it 13 digits.
+//the int arg is the number of zero to be added.
+syntax String ::=     pad0(String)      [function]
+                    | pad0(String, Int) [function]
+
+rule pad0(S:String) => pad0(S, 13 -Int lengthString(S))
+
+rule pad0(S:String, 0) => S
+
+rule pad0(S:String, I:Int) => pad0("0" +String S, I -Int 1)
+when I >Int 0
+
+syntax Int ::= uvalueMInt(MInt)     [function, hook(#MINT:uvalue), smtlib(bv2int)]
 
 // the min val of double in java
 syntax Float ::= "DoubleMinVal" | "DoubleMaxVal"
@@ -25,22 +36,21 @@ syntax Float ::= nextDown(Float) [function]
 //FFFFFFFFFFFFF is eq to 4503599627370495
 //auxiliary functions for computing ajacent double values.
 syntax Float ::= incF0(String, Int) [function]
+                   //three args are prefix, significand, and power resp.
                | incF1(String, Int, Int) [function]
 
+//there are 14 chars in the hex str, first 1 is either 0 or 1, the remaining 13 are significands.
 rule incF0(Fl:String, E:Int) => incF1(substrString(Fl, 0, 1), String2Base(substrString(Fl, 1,
 lengthString(Fl)), 16), E)
-when lengthString(Fl) ==Int 14
 
-rule incF0(Fl:String, E:Int) => -1.0 //should not reach this case.
-when notBool (lengthString(Fl) ==Int 14)
 
 rule incF1(Prefix:String, Significand:Int, Power:Int) =>
 String2Float("0x" +String Prefix +String ".0" +String "p" +String Int2String(Power +Int 1))
 when Significand ==Int 4503599627370495
 
 rule incF1(Prefix:String, Significand:Int, Power:Int) =>
-String2Float("0x" +String Prefix +String "." +String Int2String(Significand +Int 1) +String "p"
-+String Int2String(Power))
+String2Float("0x" +String Prefix +String "." +String pad0(Base2String(Significand +Int 1, 16)) +String
+ "p" +String Int2String(Power))
 when notBool (Significand ==Int 4503599627370495)
 
 //build the hex string of a float, given its significand's string and exponent.
@@ -70,9 +80,7 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) => Float2String(incF1(substrString("10000000000000", 0, 1), String2Base
-(substrString("10000000000000", 1,
-                                             lengthString("10000000000000")), 16), 0), "%Ra")
+rule toString(Fl:Float :: _) => Float2String(nextUp(Fl), "%Ra")
 
 //Float2String(incF0("10000000000000",0), "%Ra")
 

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -69,8 +69,13 @@ rule toString(I:Int :: T:Type) => Int2String(I)
 
 rule toString(Fl:Float :: _) => javaDouble2String(Fl)
 
-//toString(isDiffFl(nextDown(7.0 /Float 1.2), "5.83333333333333", nextUp(7.0 /Float 1.2)))
+//Float2String(Fl, "%Re") +String ";\n" +String Float2String(Fl, "%.18Rf")
+// +String ";\nnextDown: " +String Float2String(nextDown(Fl), "%.18Rf")
+// +String ";\nnextUp: " +String Float2String(nextUp(Fl), "%.18Rf")
+// +String ";\nmy: " +String javaDouble2String(Fl)
 
+//toString(isDiffFl(nextDown(7.0 /Float 1.2), "5.83333333333333", nextUp(7.0 /Float 1.2)))
+//
 //toString(isDiffFl(nextDown(0.017), "0.017000000000000001", nextUp(0.017)))
 
 //javaDouble2String(Fl)

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -35,28 +35,8 @@ syntax String ::= javaDouble2String(Float)  [function]
                    //If the absolute value of the target float is inside the range [low,high),
         //then it will be printed in decimal format, owise, scientific notation will be used.
                 | javaDouble2StringAux(Float, Float, Float)  [function]
-
-//the three args: nextDown, target double, nextUp
-                | chooseFromCandidateDoubleStr0(Float, Float, Float) [function]
-
-//First three args are the same as the above function, the last one is the number at which pos the
-//target double is distinguishable from its adjacent double values
-                | chooseFromCandidateDoubleStr1(Float, Float, Float, Int) [function]
-
-                //the 4 args are: nextDown, nextUp, candidate1, candidate2
-                //At first, the candidate1 is transformed back to float and compare with its
-                //neighbors, if ok then return it, owise tries the candidate2, then candidate3...
-                | chooseFromCandidateDoubleStr2(Float, Float, String, String, String) [function]
-                | chooseFromCandidateDoubleStr3(Float, Float, String, String) [function]
-
                 | check0(String, Bool) [function]
 
-
-//check whether the string (representing a float) is diff from both of the two floats.
-syntax Bool ::= isDiffFl(Float, String, Float) [function]
-               | isDiff(Float, Float, Float) [function]
-rule isDiffFl(F0:Float, F1:String, F2:Float) => isDiff(F0, String2Float(F1), F2)
-rule isDiff(F0:Float, F1:Float, F2:Float) => F1 =/=Float F0 andBool F1 =/=Float F2
 
 rule javaDouble2String(DoubleNegInf) => "-Infinity"
 rule javaDouble2String(DoublePosInf) => "Infinity"
@@ -65,8 +45,8 @@ rule javaDouble2String(DoubleNaN) => "NaN"
 rule javaDouble2String(Fl:Float) => javaDouble2StringAux(10.0^Float(-3.0), Fl, 10.0^Float(7.0))
 [owise]
 
-rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) => chooseFromCandidateDoubleStr0
-                                                                (nextDown(Fl), Fl, nextUp(Fl))
+rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) =>
+Float2String(Fl, "%." +String Int2String(numOfDigitsPreserved(Fl)) +String "Rg")
 when (Fl >=Float Low andBool Fl <Float High) orBool
      (Fl <Float --Float Low andBool Fl >=Float --Float High)
 
@@ -75,31 +55,6 @@ rule javaDouble2StringAux(_, --Float 0.0, _) => "-0.0"
 
 //The other double numbers should be printed in "ScientificNotation".
 rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) => Float2String(Fl, "%Re") [owise]
-
-
-rule chooseFromCandidateDoubleStr0(F0:Float, F1:Float, F2:Float) =>
-    chooseFromCandidateDoubleStr1(F0, F1, F2, numOfDigitsPreserved1(F0, F1, F2))
-
-rule chooseFromCandidateDoubleStr1(Lower:Float, Cur:Float, Higher:Float, N:Int) =>
-    chooseFromCandidateDoubleStr2(Lower, Higher,
-                            Float2String(Cur, "%." +String Int2String(N -Int 1) +String "Rg"),
-                            Float2String(Cur, "%." +String Int2String(N) +String "Rg"),
-                            Float2String(Cur, "%." +String Int2String(N +Int 1) +String "Rg"))
-
-
-rule chooseFromCandidateDoubleStr2(Lower:Float, Higher:Float, Cand1:String, Cand2:String,
-Cand3:String) => Cand1
-when isDiffFl(Lower, Cand1, Higher)
-
-rule chooseFromCandidateDoubleStr2(Lower:Float, Higher:Float, Cand1:String, Cand2:String,
-Cand3:String) => chooseFromCandidateDoubleStr3(Lower:Float, Higher:Float, Cand2, Cand3)
-[owise]
-
-rule chooseFromCandidateDoubleStr3(Lower:Float, Higher:Float, Cand2:String, Cand3:String) => Cand2
-when isDiffFl(Lower, Cand2, Higher)
-
-rule chooseFromCandidateDoubleStr3(Lower:Float, Higher:Float, Cand2:String, Cand3:String) => Cand3
-[owise]
 
 /*@ Converts all possible Java values into String. Used mostly for printing and String + operator.
     Conversion for other value forms is defined in other modules.
@@ -113,23 +68,12 @@ rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
 rule toString(Fl:Float :: _) => javaDouble2String(Fl)
+
+//toString(isDiffFl(nextDown(7.0 /Float 1.2), "5.83333333333333", nextUp(7.0 /Float 1.2)))
+
 //toString(isDiffFl(nextDown(0.017), "0.017000000000000001", nextUp(0.017)))
 
 //javaDouble2String(Fl)
-/*
-"0.017 in hex str: " +String
-Float2String(0.017, "%Re") +String ";\n0.017 in 18 digits:" +String Float2String(0.017, "%.18Rf")
- +String ";\n0.017's next down:" +String Float2String(nextDown(0.017), "%.18Rf")
- +String ";\n0.017's next up:" +String Float2String(nextUp(0.017), "%.18Rf")
- +String ";\n0.017 my out: " +String javaDouble2String(0.017)
- +String ";\nNumOfDigitsPreserved is " +String Int2String(numOfDigitsPreserved(0.017))
- +String ";\nString2Float: " +String Float2String(String2Float("0.017000000000000001"))
- +String ";\nString2Float: " +String Float2String(String2Float("1.7000000000000001e-02"))
- +String ";\nString of nextUp: " +String Float2String(String2Float("0.017000000000000005"))
- +String "\n=? "
- //when (( (nextDown(0.017)) =/=Float (String2Float("0.017000000000000001")) ))
- // (( (nextUp(0.017)) =/=Float (String2Float("0.017000000000000001")) ))
-*/
 
 //java: 9.0E-4
 /*

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -3,6 +3,7 @@ module TO-STRING
     imports CORE-FUNCTIONS
     imports AUX-STRINGS
     imports SYNTAX-CONVERSIONS
+    imports JAVA-MATH
 
 
 //add 0 to the beginning of the hex string to make it 13 digits.
@@ -18,76 +19,6 @@ when I <=Int 0
 rule pad0(S:String, I:Int) => pad0("0" +String S, I -Int 1)
 when I >Int 0
 
-syntax Int ::= uvalueMInt(MInt)     [function, hook(#MINT:uvalue), smtlib(bv2int)]
-
-// the min val of double in java
-syntax Float ::= "DoubleMinVal" | "DoubleMaxVal"
-syntax Float ::= "DoubleNegInf" | "DoublePosInf"
-syntax Float ::= "DoubleNaN"
-
-rule DoubleMinVal => minValueFloat(53, 11)
-rule DoubleMaxVal => maxValueFloat(53, 11)
-rule DoubleNegInf => minusInfinity(53, 11)
-rule DoublePosInf => plusInfinity(53, 11)
-rule DoubleNaN => fpNaN(53, 11)
-
-syntax Float ::= nextUp(Float) [function]
-syntax Float ::= nextDown(Float) [function]
-
-//FFFFFFFFFFFFF is eq to 4503599627370495
-//auxiliary functions for computing ajacent double values.
-syntax Float ::= incF0(String, Int) [function]
-                   //three args are prefix, significand, and power resp.
-               | incF1(String, Int, Int) [function]
-
-               | decF0(String, Int) [function]
-               //three args are prefix, significand, and power resp.
-               | decF1(String, Int, Int) [function]
-
-//there are 14 chars in the hex str, first 1 is either 0 or 1, the remaining 13 are significands.
-rule incF0(Fl:String, E:Int) => incF1(substrString(Fl, 0, 1), String2Base(substrString(Fl, 1,
-lengthString(Fl)), 16), E)
-
-
-rule incF1(Prefix:String, Significand:Int, Power:Int) =>
-String2Float("0x" +String Prefix +String ".0" +String "p" +String Int2String(Power +Int 1))
-when Significand ==Int 4503599627370495
-
-rule incF1(Prefix:String, Significand:Int, Power:Int) =>
-String2Float("0x" +String Prefix +String "." +String pad0(Base2String(Significand +Int 1, 16)) +String
- "p" +String Int2String(Power))
-when notBool (Significand ==Int 4503599627370495)
-
-
-//=============auxiliary functions for computing next smaller double
-rule decF0(Fl:String, E:Int) => decF1(substrString(Fl, 0, 1), String2Base(substrString(Fl, 1,
-lengthString(Fl)), 16), E)
-
-
-rule decF1(Prefix:String, Significand:Int, Power:Int) =>
-String2Float("0x" +String Prefix +String ".FFFFFFFFFFFFF" +String "p" +String Int2String(Power -Int
- 1)) when Significand ==Int 0
-
-rule decF1(Prefix:String, Significand:Int, Power:Int) =>
-String2Float("0x" +String Prefix +String "." +String pad0(Base2String(Significand -Int 1, 16))
-+String "p" +String Int2String(Power))
-when notBool (Significand ==Int 0)
-
-
-//build the hex string of a float, given its significand's string and exponent.
-//syntax String ::= buildFloatHexStr(String, Int) [function]
-
-rule nextUp(DoubleNaN) => DoubleNaN
-rule nextUp(DoublePosInf) => DoublePosInf
-rule nextUp(0.0) => DoubleMinVal
-rule nextUp(Fl:Float) => incF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
-                            exponentFloat(Fl)) [owise]
-
-rule nextDown(DoubleNaN) => DoubleNaN
-rule nextDown(DoubleNegInf) => DoubleNegInf
-rule nextDown(0.0) => --Float DoubleMinVal
-rule nextDown(Fl:Float) => decF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
-                                                       exponentFloat(Fl)) [owise]
 
 /*@auxiliary function for printing Java's double value in default mode.
 //the number of digits preserved after decimal point depend solely on whether
@@ -111,41 +42,27 @@ rule diffFromPos(S1:String, S2:String) =>
 
 rule diffFromPos(S1:String, S2:String) => -1 [owise] //error state
 
-
 /*@
-1. compute the diffFromPos value for the target doubleVal and its two adjacent values.
-    Say pos1 and pos2 representing the positions at which the target double value
-     can be distinguished with its next lower / next higher double value.
-2. return the larger one between pos1 and pos2.
+The algorithm for printing a Java's double value is based on the description of Javadoc of Double.
+http://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#toString(double)
+ 1. Given a Java's double value, compute its nextDown and nextUp (two adjacent double values)
+ 2. Print them using format Float2String(Fl, "%.18Rf")
+    18 digits should be enough, cause In java, there are at most 17 digits after decimal point
+    being printed.
+ 3. Get the position after which the target double can be distinguished from its neighbors.
+ 4. There are two candidate string representation. Suppose the position computed by last step
+    is N, then the two candidate string are:
+     Candidate1: Float2String(TargetFl, "%." +String Int2String(N) +String "Rg")
+     Candidate2: Float2String(TargetFl, "%." +String Int2String(N +Int 1) +String "Rg")
+
+    In most cases, Candidate1 is the right one, but occasionaly, e.g. the number 7 % 1.2, the
+    Candidate 1 will become the same as its left-neighbor's string representation, i.e. "1"
+
+ 5. Additional check is performed to decide which candidate to use: the Candidate 1 will be
+    parsed back to float and comared with its left and right neighbors. If they are
+    distinguishable, then Candidate 1 will be returned as the string representation of the
+    target double value, otherwise, Candidate 2 will be returned.
 */
-syntax Int ::= numOfDigitsPreserved(Float)  [function]
-            | numOfDigitsPreserved1(Float, Float, Float) [function]
-            //the string representation of the format "%.17Rf"
-            | numOfDigitsPreserved2(String, String, String) [function]
-            //the substr after decimal points: all of them should have 17 chars
-            | numOfDigitsPreserved3(String, String, String) [function]
-
-syntax String ::= getFractionalPart(String)  [function]
-rule getFractionalPart(S:String) =>
-    substrString(S, findChar(S, ".", 0) +Int 1, lengthString(S))
-
-rule numOfDigitsPreserved(Fl:Float) =>
-  numOfDigitsPreserved1(nextDown(Fl), Fl, nextUp(Fl))
-
-rule numOfDigitsPreserved1(F0:Float, F1:Float, F2:Float)
-     => numOfDigitsPreserved2(Float2String(F0, "%.18Rf"),
-                              Float2String(F1, "%.18Rf"),
-                              Float2String(F2, "%.18Rf"))
-
-rule numOfDigitsPreserved2(F0:String, F1:String, F2:String)
-    => numOfDigitsPreserved3(getFractionalPart(F0),
-                         getFractionalPart(F1),
-                         getFractionalPart(F2))
-
-rule numOfDigitsPreserved3(F0:String, F1:String, F2:String)
-    => maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2))
-
-
 syntax String ::= javaDouble2String(Float)  [function]
 //the three args: nextDown, target double, nextUp
                 | chooseFromCandidateDoubleStr0(Float, Float, Float) [function]

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -196,46 +196,6 @@ rule toString(I:Int :: T:Type) => Int2String(I)
 
 rule toString(Fl:Float :: _) => javaDouble2String(Fl)
 
-
-/*
-                                Float2String(Fl, "%." +String
-                                Int2String(numOfDigitsPreserved(Fl)) +String "Rg")
-
-
-                             +String ";;\n nextDown: " +String Float2String(nextDown(Fl), "%.28Rf")
-                             +String ";;\tTarget: " +String Float2String(Fl, "%.28Rf")
-                             +String ";;\tnextUp: " +String Float2String(nextUp(Fl), "%.28Rf")
-
-                             +String ";;\tNumOfDigitsPreserved:\t" +String Int2String(numOfDigitsPreserved(Fl))
-                             +String ";;\tTarget in round mode (16RNf): " +String
-                             Float2String(Fl, "%.16RNf")
-      +String ";;\tTarget in round 16 RNg: " +String Float2String(Fl, "%.16RNg")
-
-                      +String ";;\tTarget in round 18 RNf: " +String Float2String(Fl, "%.18RNf")
-                      +String ";;\tTarget in round 18 RNg: " +String Float2String(Fl, "%.18RNg")
-
-
-
-Float2String(String2Float("0x" +String "1" +String "." +String Int2String(0 +Int 1)
-+String "p" +String Int2String(0)), "%Ra")
-
- //Int2String(String2Base("0000000000000", 16)) +String ";;"
-//+String Int2String(exponentFloat(Fl)) +String ";;len: " +String Int2String(lengthString
-//("10000000000000"))
-
-//Float2String(incF1("1", 0, 0), "%Ra")
-//Base2String(uvalueMInt(significandFloat(Fl)), 16) +String
- //  ", expo:" +String Int2String(exponentFloat(Fl)) +String "; " +String Float2String(String2Float
- //  ("0x1.0p0"))
-
- //Float2String(nextUp(Fl), "%Ra")
-
-//Base2String(uvalueMInt(significandFloat(Fl)), 16)
-//Float2String(String2Float("0x1.3ae147ae147adp+0"), "%.18Rf") //nextDown
-//+String ";\t" +String Float2String(String2Float("0x1.3ae147ae147aep+0"), "%.18Rf") //target float
-//+String ";\t" +String Float2String(String2Float("0x1.3ae147ae147afp+0"), "%.18Rf") //nextUp
-*/
-
 rule toString(true::_) => "true"
 rule toString(false::_) => "false"
 rule toString(null::_) => "null"

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -24,14 +24,15 @@ syntax Float ::= nextDown(Float) [function]
 
 //FFFFFFFFFFFFF is eq to 4503599627370495
 //auxiliary functions for computing ajacent double values.
-syntax Float ::= incF0(String, Int) | incF1(String, Int, Int)
+syntax Float ::= incF0(String, Int) [function]
+               | incF1(String, Int, Int) [function]
 
 rule incF0(Fl:String, E:Int) => incF1(substrString(Fl, 0, 1), String2Base(substrString(Fl, 1,
 lengthString(Fl)), 16), E)
 when lengthString(Fl) ==Int 14
 
 rule incF0(Fl:String, E:Int) => -1.0 //should not reach this case.
-when notBool lengthString(Fl) ==Int 14
+when notBool (lengthString(Fl) ==Int 14)
 
 rule incF1(Prefix:String, Significand:Int, Power:Int) =>
 String2Float("0x" +String Prefix +String ".0" +String "p" +String Int2String(Power +Int 1))
@@ -69,8 +70,21 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) => Float2String(incF1("1", 0, 0), "%Ra")
+rule toString(Fl:Float :: _) => Float2String(incF1(substrString("10000000000000", 0, 1), String2Base
+(substrString("10000000000000", 1,
+                                             lengthString("10000000000000")), 16), 0), "%Ra")
 
+//Float2String(incF0("10000000000000",0), "%Ra")
+
+/*
+Float2String(String2Float("0x" +String "1" +String "." +String Int2String(0 +Int 1)
++String "p" +String Int2String(0)), "%Ra")
+
+ //Int2String(String2Base("0000000000000", 16)) +String ";;"
+//+String Int2String(exponentFloat(Fl)) +String ";;len: " +String Int2String(lengthString
+//("10000000000000"))
+
+//Float2String(incF1("1", 0, 0), "%Ra")
 //Base2String(uvalueMInt(significandFloat(Fl)), 16) +String
  //  ", expo:" +String Int2String(exponentFloat(Fl)) +String "; " +String Float2String(String2Float
  //  ("0x1.0p0"))
@@ -81,7 +95,7 @@ rule toString(Fl:Float :: _) => Float2String(incF1("1", 0, 0), "%Ra")
 //Float2String(String2Float("0x1.3ae147ae147adp+0"), "%.18Rf") //nextDown
 //+String ";\t" +String Float2String(String2Float("0x1.3ae147ae147aep+0"), "%.18Rf") //target float
 //+String ";\t" +String Float2String(String2Float("0x1.3ae147ae147afp+0"), "%.18Rf") //nextUp
-
+*/
 
 
 rule toString(true::_) => "true"

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -12,7 +12,8 @@ syntax String ::=     pad0(String)      [function]
 
 rule pad0(S:String) => pad0(S, 13 -Int lengthString(S))
 
-rule pad0(S:String, 0) => S
+rule pad0(S:String, I:Int) => S
+when I <=Int 0
 
 rule pad0(S:String, I:Int) => pad0("0" +String S, I -Int 1)
 when I >Int 0
@@ -132,9 +133,9 @@ rule numOfDigitsPreserved(Fl:Float) =>
   numOfDigitsPreserved1(nextDown(Fl), Fl, nextUp(Fl))
 
 rule numOfDigitsPreserved1(F0:Float, F1:Float, F2:Float)
-     => numOfDigitsPreserved2(Float2String(F0, "%.17Rf"),
-                              Float2String(F1, "%.17Rf"),
-                              Float2String(F2, "%.17Rf"))
+     => numOfDigitsPreserved2(Float2String(F0, "%.18Rf"),
+                              Float2String(F1, "%.18Rf"),
+                              Float2String(F2, "%.18Rf"))
 
 rule numOfDigitsPreserved2(F0:String, F1:String, F2:String)
     => numOfDigitsPreserved3(getFractionalPart(F0),
@@ -145,6 +146,45 @@ rule numOfDigitsPreserved3(F0:String, F1:String, F2:String)
     => maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2))
 
 
+//Implement the rounding mode of 'N' (round to nearest) manually in order to pass the tests.
+//round(s,i) where s is the target float number in string format and int i is the number of
+//fractional digits after the decimal point;
+syntax String ::= round(String, Int) [function]
+                //use this helper method so that only compute the pos of decimal point one time
+                //the arg in the middle is the pos of "."
+                | round1(String, Int, Int) [function]
+
+ //The method incI analyzes a float string in this format: A.BX, where X is the last digit
+ //and the length of B is the number of preserved fractional digits (denoted by n)
+ //The four args are A, B, X, n
+                | incI(Int, Int, Int, Int)  [function]
+                //helper function to avoid the repetition of computation
+                | incNoOverflow(String, String, Int)  [function]
+
+rule round(S:String, N:Int) => round1(S, findChar(S, ".", 0), N)
+
+rule round1(S:String, Pos:Int, N:Int) => incI(String2Int(substrString(S, 0, Pos)),
+                            String2Int(substrString(S, Pos +Int 1, Pos +Int 1 +Int N)),
+                            String2Int(substrString(S, Pos +Int 1 +Int N, Pos +Int 2 +Int N)),
+                             N)
+
+rule incI(A:Int, B:Int, X:Int, N:Int) =>
+incNoOverflow(Int2String(A), Int2String(B), N)
+when X <Int 5
+
+//inc by one unit, no overflow in fractional part
+rule incI(A:Int, B:Int, X:Int, N:Int) =>
+incNoOverflow(Int2String(A), Int2String(B +Int 1), N)
+when X >=Int 5 andBool (B +Int 1 <Int 10^N)
+
+//inc by one unit, has overflow in fractional part
+rule incI(A:Int, B:Int, X:Int, N:Int) =>
+incNoOverflow(Int2String(A +Int 1), "0", 1)
+when X >=Int 5 andBool (B +Int 1 >=Int 10^N)
+
+
+rule incNoOverflow(A:String, B:String, N:Int) =>
+  A +String "." +String pad0(B, N -Int lengthString(B))
 
 /*@ Converts all possible Java values into String. Used mostly for printing and String + operator.
     Conversion for other value forms is defined in other modules.
@@ -156,18 +196,32 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) => Int2String(diffFromPos("1007","1017"))
- +String "==3 && "
- //+String getFractionalPart("12.527") +String "==527 && "
- //   +String Int2String(numOfDigitsPreserved3("100000", "100011", "100012"))
- //   +String " == 6"
+rule toString(Fl:Float :: _) =>
 
-//Float2String(Fl, "%." +String
-//                      Int2String(numOfDigitsPreserved(Fl)) +String "RNg")
+
+
+/*
+                                Float2String(Fl, "%." +String
+                                Int2String(numOfDigitsPreserved(Fl)) +String "Rg")
+
+
+                             +String ";;\n nextDown: " +String Float2String(nextDown(Fl), "%.28Rf")
+                             +String ";;\tTarget: " +String Float2String(Fl, "%.28Rf")
+                             +String ";;\tnextUp: " +String Float2String(nextUp(Fl), "%.28Rf")
+
+                             +String ";;\tNumOfDigitsPreserved:\t" +String Int2String(numOfDigitsPreserved(Fl))
+                             +String ";;\tTarget in round mode (16RNf): " +String
+                             Float2String(Fl, "%.16RNf")
+      +String ";;\tTarget in round 16 RNg: " +String Float2String(Fl, "%.16RNg")
+
+                      +String ";;\tTarget in round 18 RNf: " +String Float2String(Fl, "%.18RNf")
+                      +String ";;\tTarget in round 18 RNg: " +String Float2String(Fl, "%.18RNg")
+
+
 
 //Float2String(incF0("10000000000000",0), "%Ra")
 
-/*
+
 Float2String(String2Float("0x" +String "1" +String "." +String Int2String(0 +Int 1)
 +String "p" +String Int2String(0)), "%Ra")
 

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -88,8 +88,59 @@ rule nextDown(0.0) => --Float DoubleMinVal
 rule nextDown(Fl:Float) => decF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
                                                        exponentFloat(Fl)) [owise]
 
-syntax String ::= fst17AfterDot(Float) [function]
-rule fst17AfterDot(Fl) => Float2String(Fl, "%.22Rf")
+/*@auxiliary function for printing Java's double value in default mode.
+//the number of digits preserved after decimal point depend solely on whether
+// that amount of significands can distinguish the target value with its adjacent
+//double values.
+//This function returns the pos at which two strings are distinguishable
+//the two input string are assumed to have equal length.
+*/
+syntax Int ::= diffFromPos(String, String) [function]
+rule diffFromPos(S1:String, S2:String) => 1
+    when substrString(S1, 0, 1) =/=String substrString(S2, 0, 1)
+
+rule diffFromPos(S1:String, S2:String) => 0
+    when S1 ==String "" orBool S2 ==String ""
+
+rule diffFromPos(S1:String, S2:String) =>
+    1 + diffFromPos(substrString(S1, 1, lengthString(S1)),
+                    substrString(S2, 1, lengthString(S2)))
+    when substrString(S1, 0, 1) ==String substrString(S2, 0, 1)
+
+/*@
+1. compute the diffFromPos value for the target doubleVal and its two adjacent values.
+    Say pos1 and pos2 representing the positions at which the target double value
+     can be distinguished with its next lower / next higher double value.
+2. return the larger one between pos1 and pos2.
+*/
+syntax Int ::= numOfDigitsPreserved(Float)  [function]
+            | numOfDigitsPreserved1(Float, Float, Float) [function]
+            //the string representation of the format "%.17Rf"
+            | numOfDigitsPreserved2(String, String, String) [function]
+            //the substr after decimal points: all of them should have 17 chars
+            | numOfDigitsPreserved3(String, String, String) [function]
+
+syntax String ::= getFractionalPart(String)  [function]
+rule getFractionalPart(S:String) =>
+    substrString(S, findChar(S, ".", 0) +Int 1, lengthString(S))
+
+rule numOfDigitsPreserved(Fl:Float) =>
+  numOfDigitsPreserved1(nextDown(Fl), Fl, nextUp(Fl))
+
+rule numOfDigitsPreserved1(F0:Float, F1:Float, F2:Float)
+     => numOfDigitsPreserved2(Float2String(F0, "%.17Rf"),
+                              Float2String(F1, "%.17Rf"),
+                              Float2String(F2, "%.17Rf"))
+
+rule numOfDigitsPreserved2(F0:String, F1:String, F2:String)
+    => numOfDigitsPreserved3(getFractionalPart(F0),
+                         getFractionalPart(F1),
+                         getFractionalPart(F2))
+
+rule numOfDigitsPreserved3(F0:String, F1:String, F2:String)
+    => maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2))
+
+
 
 /*@ Converts all possible Java values into String. Used mostly for printing and String + operator.
     Conversion for other value forms is defined in other modules.
@@ -101,10 +152,8 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) => Float2String(nextUp(Fl), "%Ra") +String ";;\t"
- +String Float2String(Fl, "%RA") +String ";;\t" +String
-Float2String(nextDown(Fl), "%RA") +String ";;\tone down's Float\t" +String
-                                  Float2String(String2Float("0x1.fffffffffffffp-1"), "%RA")
+rule toString(Fl:Float :: _) => Float2String(Fl, "%." +String
+                      Int2String(numOfDigitsPreserved(Fl)) +String "RNg")
 
 //Float2String(incF0("10000000000000",0), "%Ra")
 
@@ -128,7 +177,6 @@ Float2String(String2Float("0x" +String "1" +String "." +String Int2String(0 +Int
 //+String ";\t" +String Float2String(String2Float("0x1.3ae147ae147aep+0"), "%.18Rf") //target float
 //+String ";\t" +String Float2String(String2Float("0x1.3ae147ae147afp+0"), "%.18Rf") //nextUp
 */
-
 
 rule toString(true::_) => "true"
 rule toString(false::_) => "false"

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -4,6 +4,30 @@ module TO-STRING
     imports AUX-STRINGS
     imports SYNTAX-CONVERSIONS
 
+// the min val of double in java
+syntax Float ::= Double_MinVal | Double_MaxVal
+syntax Float ::= Double_NegInf | Double_PosInf
+syntax Float ::= Double_NaN
+
+rule Double_MinVal => minValueFloat(53, 11)
+rule Double_MaxVal => maxValueFloat(53, 11)
+rule Double_NegInf => minusInfinity(53, 11)
+rule Double_PosInf => plusInfinity(53, 11)
+rule Double_NaN => fpNaN(53, 11)
+
+syntax Float ::= nextUp(Float) [function]
+syntax Float ::= nextDown(Float) [function]
+
+rule nextUp(Double_NaN) = Double_NaN
+rule nextUp(Double_PosInf) = Double_PosInf
+rule nextUp(0) = Double_MinVal
+rule nextUp(Fl:Float) = Fl +Float Double_MinVal [owise]
+
+rule nextDown(Double_NaN) = Double_NaN
+rule nextDown(Double_NegInf) = Double_NegInf
+rule nextDown(0) = --Float Double_MinVal
+rule nextDown(Fl:Float) = Fl -Float Double_MinVal [owise]
+
 /*@ Converts all possible Java values into String. Used mostly for printing and String + operator.
     Conversion for other value forms is defined in other modules.
 */

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -43,6 +43,8 @@ syntax String ::= javaDouble2String(Float)  [function]
                 //neighbors, if ok then return it, owise return the candidate2
                 | chooseFromCandidateDoubleStr2(Float, Float, String, String) [function]
 
+                | check0(String, Bool) [function]
+
 
 //check whether the string (representing a float) is diff from both of the two floats.
 syntax Bool ::= isDiffFl(Float, String, Float) [function]
@@ -50,7 +52,27 @@ syntax Bool ::= isDiffFl(Float, String, Float) [function]
 rule isDiffFl(F0:Float, F1:String, F2:Float) => isDiff(F0, String2Float(F1), F2)
 rule isDiff(F0:Float, F1:Float, F2:Float) => F1 =/=Float F0 andBool F1 =/=Float F2
 
+rule javaDouble2String(DoubleNegInf) => "-Infinity"
+rule javaDouble2String(DoublePosInf) => "Infinity"
+rule javaDouble2String(DoubleNaN) => "NaN"
+
+
 rule javaDouble2String(Fl:Float) => chooseFromCandidateDoubleStr0(nextDown(Fl), Fl, nextUp(Fl))
+when Fl >=Float 10.0^Float(-3.0) andBool Fl <Float 10.0^Float(7.0)
+
+
+rule javaDouble2String(Fl:Float) => "neg"
+when signFloat(Fl)
+
+rule javaDouble2String(Fl:Float) => "pos"
+when notBool signFloat(Fl)
+
+//check0(Float2String(Fl, "%RE"), )
+
+rule javaDouble2String(Fl:Float) => "Undef"
+[owise]
+rule check0(S:String, B:Bool) => "check0"
+
 
 rule chooseFromCandidateDoubleStr0(F0:Float, F1:Float, F2:Float) =>
     chooseFromCandidateDoubleStr1(F0, F1, F2, numOfDigitsPreserved1(F0, F1, F2))

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -31,6 +31,11 @@ http://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#toString(double)
     target double value, otherwise, Candidate 2 will be returned.
 */
 syntax String ::= javaDouble2String(Float)  [function]
+                   //The three args are lower bound low, target float, upper bound high,
+                   //If the absolute value of the target float is inside the range [low,high),
+        //then it will be printed in decimal format, owise, scientific notation will be used.
+                | javaDouble2StringAux(Float, Float, Float)  [function]
+
 //the three args: nextDown, target double, nextUp
                 | chooseFromCandidateDoubleStr0(Float, Float, Float) [function]
 
@@ -56,22 +61,18 @@ rule javaDouble2String(DoubleNegInf) => "-Infinity"
 rule javaDouble2String(DoublePosInf) => "Infinity"
 rule javaDouble2String(DoubleNaN) => "NaN"
 
-
-rule javaDouble2String(Fl:Float) => chooseFromCandidateDoubleStr0(nextDown(Fl), Fl, nextUp(Fl))
-when Fl >=Float 10.0^Float(-3.0) andBool Fl <Float 10.0^Float(7.0)
-
-
-rule javaDouble2String(Fl:Float) => "neg"
-when signFloat(Fl)
-
-rule javaDouble2String(Fl:Float) => "pos"
-when notBool signFloat(Fl)
-
-//check0(Float2String(Fl, "%RE"), )
-
-rule javaDouble2String(Fl:Float) => "Undef"
+rule javaDouble2String(Fl:Float) => javaDouble2StringAux(10.0^Float(-3.0), Fl, 10.0^Float(7.0))
 [owise]
-rule check0(S:String, B:Bool) => "check0"
+
+rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) => chooseFromCandidateDoubleStr0
+                                                                (nextDown(Fl), Fl, nextUp(Fl))
+when (Fl >=Float Low andBool Fl <Float High) orBool
+     (Fl <Float --Float Low andBool Fl >=Float --Float High)
+
+rule javaDouble2StringAux(_, 0.0, _) => "0.0"
+rule javaDouble2StringAux(_, --Float 0.0, _) => "-0.0"
+
+rule javaDouble2StringAux(Low:Float, Fl:Float, High:Float) => "ScientificNotation" [owise]
 
 
 rule chooseFromCandidateDoubleStr0(F0:Float, F1:Float, F2:Float) =>
@@ -101,6 +102,15 @@ rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
 rule toString(Fl:Float :: _) => javaDouble2String(Fl)
+//java: 9.0E-4
+/*
+Float2String(0.0009, "%Re") +String ";\t" +String Float2String(0.0009, "%.15Re")
+ +String ";\t" +String Float2String(0.0009, "%.16Re")
+  +String ";\t" +String Float2String(0.0009, "%.17Re")
+  +String ";\n" +String  chooseFromCandidateDoubleStr0(nextDown(0.0009), 0.0009, nextUp(0.0009))
+*/
+//javaDouble2String(Fl)
+
 
 rule toString(true::_) => "true"
 rule toString(false::_) => "false"

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -146,18 +146,10 @@ rule numOfDigitsPreserved3(F0:String, F1:String, F2:String)
     => maxInt(diffFromPos(F0, F1), diffFromPos(F1, F2))
 
 
-
-syntax String ::= incNoOverflow(String, String, Int)  [function]
-                | incI(Int, Int, Int, Int)  [function]
-                | round1(String, Int, Int) [function]
-                | round0(String, Int) [function]
-
-
-/*
 //Implement the rounding mode of 'N' (round to nearest) manually in order to pass the tests.
 //round(s,i) where s is the target float number in string format and int i is the number of
 //fractional digits after the decimal point;
-syntax String ::= round(String, Int) [function]
+syntax String ::= round0(String, Int) [function]
                 //use this helper method so that only compute the pos of decimal point one time
                 //the arg in the middle is the pos of "."
                 | round1(String, Int, Int) [function]
@@ -169,7 +161,7 @@ syntax String ::= round(String, Int) [function]
                 //helper function to avoid the repetition of computation
                 | incNoOverflow(String, String, Int)  [function]
 
-           */
+
 
 rule round0(S:String, N:Int) => round1(S, findChar(S, ".", 0), N)
 
@@ -216,11 +208,12 @@ rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
 
-rule toString(Fl:Float :: _) => round0("100.99634", 2)
+rule toString(Fl:Float :: _) =>
+//round0("100.99634", 2)
 //round1("100.99634", 3, 2)
 //"" +String incI(100,99,6,2)
 
-//round(Float2String(Fl, "%.18Rf"), numOfDigitsPreserved(Fl))
+round0(Float2String(Fl, "%.18Rf"), numOfDigitsPreserved(Fl))
 
 
 

--- a/src/exec/to-string.k
+++ b/src/exec/to-string.k
@@ -4,29 +4,60 @@ module TO-STRING
     imports AUX-STRINGS
     imports SYNTAX-CONVERSIONS
 
-// the min val of double in java
-syntax Float ::= Double_MinVal | Double_MaxVal
-syntax Float ::= Double_NegInf | Double_PosInf
-syntax Float ::= Double_NaN
 
-rule Double_MinVal => minValueFloat(53, 11)
-rule Double_MaxVal => maxValueFloat(53, 11)
-rule Double_NegInf => minusInfinity(53, 11)
-rule Double_PosInf => plusInfinity(53, 11)
-rule Double_NaN => fpNaN(53, 11)
+  syntax Int ::= svalueMInt(MInt)     [function, hook(#MINT:svalue)]
+  | uvalueMInt(MInt)     [function, hook(#MINT:uvalue), smtlib(bv2int)]
+
+// the min val of double in java
+syntax Float ::= "DoubleMinVal" | "DoubleMaxVal"
+syntax Float ::= "DoubleNegInf" | "DoublePosInf"
+syntax Float ::= "DoubleNaN"
+
+rule DoubleMinVal => minValueFloat(53, 11)
+rule DoubleMaxVal => maxValueFloat(53, 11)
+rule DoubleNegInf => minusInfinity(53, 11)
+rule DoublePosInf => plusInfinity(53, 11)
+rule DoubleNaN => fpNaN(53, 11)
 
 syntax Float ::= nextUp(Float) [function]
 syntax Float ::= nextDown(Float) [function]
 
-rule nextUp(Double_NaN) = Double_NaN
-rule nextUp(Double_PosInf) = Double_PosInf
-rule nextUp(0) = Double_MinVal
-rule nextUp(Fl:Float) = Fl +Float Double_MinVal [owise]
+//FFFFFFFFFFFFF is eq to 4503599627370495
+//auxiliary functions for computing ajacent double values.
+syntax Float ::= incF0(String, Int) | incF1(String, Int, Int)
 
-rule nextDown(Double_NaN) = Double_NaN
-rule nextDown(Double_NegInf) = Double_NegInf
-rule nextDown(0) = --Float Double_MinVal
-rule nextDown(Fl:Float) = Fl -Float Double_MinVal [owise]
+rule incF0(Fl:String, E:Int) => incF1(substrString(Fl, 0, 1), String2Base(substrString(Fl, 1,
+lengthString(Fl)), 16), E)
+when lengthString(Fl) ==Int 14
+
+rule incF0(Fl:String, E:Int) => -1.0 //should not reach this case.
+when notBool lengthString(Fl) ==Int 14
+
+rule incF1(Prefix:String, Significand:Int, Power:Int) =>
+String2Float("0x" +String Prefix +String ".0" +String "p" +String Int2String(Power +Int 1))
+when Significand ==Int 4503599627370495
+
+rule incF1(Prefix:String, Significand:Int, Power:Int) =>
+String2Float("0x" +String Prefix +String "." +String Int2String(Significand +Int 1) +String "p"
++String Int2String(Power))
+when notBool (Significand ==Int 4503599627370495)
+
+//build the hex string of a float, given its significand's string and exponent.
+//syntax String ::= buildFloatHexStr(String, Int) [function]
+
+rule nextUp(DoubleNaN) => DoubleNaN
+rule nextUp(DoublePosInf) => DoublePosInf
+rule nextUp(0.0) => DoubleMinVal
+rule nextUp(Fl:Float) => incF0(Base2String(uvalueMInt(significandFloat(Fl)), 16),
+                            exponentFloat(Fl)) [owise]
+
+rule nextDown(DoubleNaN) => DoubleNaN
+rule nextDown(DoubleNegInf) => DoubleNegInf
+rule nextDown(0.0) => --Float DoubleMinVal
+rule nextDown(Fl:Float) => 0.0 [owise]
+
+syntax String ::= fst17AfterDot(Float) [function]
+rule fst17AfterDot(Fl) => Float2String(Fl, "%.22Rf")
 
 /*@ Converts all possible Java values into String. Used mostly for printing and String + operator.
     Conversion for other value forms is defined in other modules.
@@ -37,7 +68,22 @@ rule toString(Str:String :: _) => Str
 rule toString(I:Int :: char) => chrChar(I)
 rule toString(I:Int :: T:Type) => Int2String(I)
     when T =/=K char
-rule toString(Fl:Float :: _) => Float2String(Fl)
+
+rule toString(Fl:Float :: _) => Float2String(incF1("1", 0, 0), "%Ra")
+
+//Base2String(uvalueMInt(significandFloat(Fl)), 16) +String
+ //  ", expo:" +String Int2String(exponentFloat(Fl)) +String "; " +String Float2String(String2Float
+ //  ("0x1.0p0"))
+
+ //Float2String(nextUp(Fl), "%Ra")
+
+//Base2String(uvalueMInt(significandFloat(Fl)), 16)
+//Float2String(String2Float("0x1.3ae147ae147adp+0"), "%.18Rf") //nextDown
+//+String ";\t" +String Float2String(String2Float("0x1.3ae147ae147aep+0"), "%.18Rf") //target float
+//+String ";\t" +String Float2String(String2Float("0x1.3ae147ae147afp+0"), "%.18Rf") //nextUp
+
+
+
 rule toString(true::_) => "true"
 rule toString(false::_) => "false"
 rule toString(null::_) => "null"


### PR DESCRIPTION
Implement a mechanism for printing Java's double so that it emits the same output as Java.
More tests should be added.
But for the double values in the range [10^-3, 10^7), toString(Float) should output the correct string now. 
For the special cases like NaN or Infinity, or a normal double outside the above range, more modifications are needed.

@laurayuwen @dwightguth 